### PR TITLE
Add Opentofu Worker

### DIFF
--- a/app/models/opentofu_worker.rb
+++ b/app/models/opentofu_worker.rb
@@ -56,5 +56,4 @@ class OpentofuWorker < MiqWorker
       "MEMCACHED_SERVER=#{::Settings.session.memcache_server}"
     ]
   end
-
 end

--- a/app/models/opentofu_worker.rb
+++ b/app/models/opentofu_worker.rb
@@ -62,11 +62,11 @@ class OpentofuWorker < MiqWorker
   end
 
   def create_podman_secret
-    return if AwesomeSpawn.run("runuser", :params => %w[secret exists opentofu-runner-secret]).success?
+    return if AwesomeSpawn.run("runuser", :params => [[:login, "manageiq"], [:command, "podman secret exists --root=#{Rails.root.join("data/containers/storage")} opentofu-runner-secret"]]).success?
 
     database_password = ActiveRecord::Base.connection_db_config.configuration_hash[:password]
     secret = {"DATABASE_PASSWORD" => database_password}
 
-    AwesomeSpawn.run!("runuser", :params => [[:login, "manageiq"], [:command, "podman secret create opentofu-runner-secret -"]], :in_data => secret.to_json)
+    AwesomeSpawn.run!("runuser", :params => [[:login, "manageiq"], [:command, "podman secret create --root=#{Rails.root.join("data/containers/storage")} opentofu-runner-secret -"]], :in_data => secret.to_json)
   end
 end

--- a/app/models/opentofu_worker.rb
+++ b/app/models/opentofu_worker.rb
@@ -41,12 +41,12 @@ class OpentofuWorker < MiqWorker
   end
 
   def unit_environment_variables
-    [
-      "DATABASE_HOSTNAME=#{database_configuration[:host]}",
-      "DATABASE_NAME=#{database_configuration[:database]}",
-      "DATABASE_USERNAME=#{database_configuration[:username]}",
-      "MEMCACHED_SERVER=#{::Settings.session.memcache_server}"
-    ]
+    {
+      "DATABASE_HOSTNAME" => database_configuration[:host],
+      "DATABASE_NAME"     => database_configuration[:database],
+      "DATABASE_USERNAME" => database_configuration[:username],
+      "MEMCACHED_SERVER"  => ::Settings.session.memcache_server
+    }
   end
 
   def create_podman_secret

--- a/app/models/opentofu_worker.rb
+++ b/app/models/opentofu_worker.rb
@@ -1,0 +1,36 @@
+class OpentofuWorker < MiqWorker
+  self.required_roles = ["embedded_terraform"]
+  self.rails_worker   = false
+
+  def self.service_base_name
+    "opentofu-runner"
+  end
+
+  def self.service_file
+    "#{service_base_name}.service"
+  end
+
+  def self.worker_deployment_name
+    "opentofu-runner"
+  end
+
+  def self.kill_priority
+    MiqWorkerType::KILL_PRIORITY_GENERIC_WORKERS
+  end
+
+  self.maximum_workers_count = 1
+
+  # There can only be a single instance running so the unit name can just be
+  # "opentofu-runner.service"
+  def unit_instance
+    ""
+  end
+
+  def container_image_name
+    "opentofu-runner"
+  end
+
+  def container_image
+    "opentofu-runner"
+  end
+end

--- a/app/models/opentofu_worker.rb
+++ b/app/models/opentofu_worker.rb
@@ -62,11 +62,11 @@ class OpentofuWorker < MiqWorker
   end
 
   def create_podman_secret
-    return if AwesomeSpawn.run("podman", :params => %w[secret exists opentofu-runner-secret]).success?
+    return if AwesomeSpawn.run("runuser", :params => %w[secret exists opentofu-runner-secret]).success?
 
     database_password = ActiveRecord::Base.connection_db_config.configuration_hash[:password]
     secret = {"DATABASE_PASSWORD" => database_password}
 
-    AwesomeSpawn.run!("podman", :params => %w[secret create opentofu-runner-secret -], :in_data => secret.to_json)
+    AwesomeSpawn.run!("runuser", :params => [[:login, "manageiq"], [:command, "podman secret create opentofu-runner-secret -"]], :in_data => secret.to_json)
   end
 end

--- a/app/models/opentofu_worker.rb
+++ b/app/models/opentofu_worker.rb
@@ -30,18 +30,6 @@ class OpentofuWorker < MiqWorker
     "opentofu-runner"
   end
 
-  def container_image_namespace
-    ENV["CONTAINER_IMAGE_NAMESPACE"]
-  end
-
-  def container_image_tag
-    ENV["CONTAINER_IMAGE_TAG"] || "latest"
-  end
-
-  def default_image
-    "#{container_image_namespace}/#{container_image_name}:#{container_image_tag}"
-  end
-
   def container_image
     ENV["OPENTOFU_RUNNER_IMAGE"] || default_image
   end

--- a/app/models/opentofu_worker.rb
+++ b/app/models/opentofu_worker.rb
@@ -30,8 +30,20 @@ class OpentofuWorker < MiqWorker
     "opentofu-runner"
   end
 
+  def container_image_namespace
+    ENV["CONTAINER_IMAGE_NAMESPACE"]
+  end
+
+  def container_image_tag
+    ENV["CONTAINER_IMAGE_TAG"] || "latest"
+  end
+
+  def default_image
+    "#{container_image_namespace}/#{container_image_name}:#{container_image_tag}"
+  end
+
   def container_image
-    "opentofu-runner"
+    ENV["OPENTOFU_RUNNER_IMAGE"] || default_image
   end
 
   def unit_config_file
@@ -56,4 +68,5 @@ class OpentofuWorker < MiqWorker
       "MEMCACHED_SERVER=#{::Settings.session.memcache_server}"
     ]
   end
+
 end

--- a/app/models/opentofu_worker.rb
+++ b/app/models/opentofu_worker.rb
@@ -1,6 +1,7 @@
 class OpentofuWorker < MiqWorker
-  self.required_roles = ["embedded_terraform"]
-  self.rails_worker   = false
+  self.required_roles        = ["embedded_terraform"]
+  self.rails_worker          = false
+  self.maximum_workers_count = 1
 
   def self.service_base_name
     "opentofu-runner"
@@ -17,8 +18,6 @@ class OpentofuWorker < MiqWorker
   def self.kill_priority
     MiqWorkerType::KILL_PRIORITY_GENERIC_WORKERS
   end
-
-  self.maximum_workers_count = 1
 
   # There can only be a single instance running so the unit name can just be
   # "opentofu-runner.service"

--- a/app/models/opentofu_worker/runner.rb
+++ b/app/models/opentofu_worker/runner.rb
@@ -1,0 +1,2 @@
+class OpentofuWorker::Runner < MiqWorker::Runner
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,4 +16,5 @@
   :level_embedded_terraform: info
 :workers:
   :worker_base:
-    :opentofu_worker: {}
+    :opentofu_worker:
+      :heartbeat_timeout:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,3 +14,6 @@
     :user:
 :log:
   :level_embedded_terraform: info
+:workers:
+  :worker_base:
+    :opentofu_worker: {}

--- a/systemd/opentofu-runner.service
+++ b/systemd/opentofu-runner.service
@@ -3,7 +3,14 @@ PartOf=opentofu-runner.target
 [Install]
 WantedBy=opentofu-runner.target
 [Service]
-ExecStart=/usr/bin/ruby -e sleep
+User=manageiq
+Group=manageiq
+ExecStartPre=/bin/rm -f /tmp/%n.cid
+ExecStart=/usr/bin/podman run --conmon-pidfile %T/%N.pid --cidfile %T/%N.cid --cgroups=no-conmon --log-driver=journald --name=opentofu-runner docker.io/manageiq/opentofu-runner:latest
+ExecStop=/usr/bin/podman stop --ignore -t 30 --cidfile %T/%N.cid
+ExecStopPost=/usr/bin/podman rm --ignore --cidfile %T/%N.cid
+ExecStopPost=/usr/bin/rm -f %T/%N.pid %T/%N.cid
+KillMode=none
 Type=simple
 Restart=always
 Slice=manageiq.slice

--- a/systemd/opentofu-runner.service
+++ b/systemd/opentofu-runner.service
@@ -6,9 +6,9 @@ WantedBy=opentofu-runner.target
 User=manageiq
 Group=manageiq
 ExecStartPre=/bin/rm -f /tmp/%n.cid
-ExecStart=/usr/bin/podman run --conmon-pidfile %T/%N.pid --cidfile %T/%N.cid --cgroup-manager=cgroupfs --cgroups=no-conmon --log-driver=journald --name=opentofu-runner --secret=opentofu-runner-secret docker.io/manageiq/opentofu-runner:latest
-ExecStop=/usr/bin/podman stop --ignore -t 30 --cidfile %T/%N.cid --cgroup-manager=cgroupfs
-ExecStopPost=/usr/bin/podman rm --ignore --cidfile %T/%N.cid --cgroup-manager=cgroupfs
+ExecStart=/usr/bin/podman run --conmon-pidfile %T/%N.pid --cidfile %T/%N.cid --cgroup-manager=cgroupfs --cgroups=no-conmon --log-driver=journald --name=opentofu-runner --secret=opentofu-runner-secret --root=/var/www/miq/vmdb/data/containers/storage docker.io/manageiq/opentofu-runner:latest
+ExecStop=/usr/bin/podman stop --ignore -t 30 --cidfile %T/%N.cid --cgroup-manager=cgroupfs --root=/var/www/miq/vmdb/data/containers/storage
+ExecStopPost=/usr/bin/podman rm --ignore --cidfile %T/%N.cid --cgroup-manager=cgroupfs --root=/var/www/miq/vmdb/data/containers/storage
 ExecStopPost=/usr/bin/rm -f %T/%N.pid %T/%N.cid
 KillMode=none
 Type=simple

--- a/systemd/opentofu-runner.service
+++ b/systemd/opentofu-runner.service
@@ -1,0 +1,7 @@
+[Unit]
+PartOf=opentofu-runner.target
+[Install]
+WantedBy=opentofu-runner.target
+[Service]
+ExecStart=/usr/bin/ruby -e 'sleep'
+Slice=manageiq.slice

--- a/systemd/opentofu-runner.service
+++ b/systemd/opentofu-runner.service
@@ -6,9 +6,9 @@ WantedBy=opentofu-runner.target
 User=manageiq
 Group=manageiq
 ExecStartPre=/bin/rm -f /tmp/%n.cid
-ExecStart=/usr/bin/podman run --conmon-pidfile %T/%N.pid --cidfile %T/%N.cid --cgroups=no-conmon --log-driver=journald --name=opentofu-runner docker.io/manageiq/opentofu-runner:latest
-ExecStop=/usr/bin/podman stop --ignore -t 30 --cidfile %T/%N.cid
-ExecStopPost=/usr/bin/podman rm --ignore --cidfile %T/%N.cid
+ExecStart=/usr/bin/podman run --conmon-pidfile %T/%N.pid --cidfile %T/%N.cid --cgroup-manager=cgroupfs --cgroups=no-conmon --log-driver=journald --name=opentofu-runner docker.io/manageiq/opentofu-runner:latest
+ExecStop=/usr/bin/podman stop --ignore -t 30 --cidfile %T/%N.cid --cgroup-manager=cgroupfs
+ExecStopPost=/usr/bin/podman rm --ignore --cidfile %T/%N.cid --cgroup-manager=cgroupfs
 ExecStopPost=/usr/bin/rm -f %T/%N.pid %T/%N.cid
 KillMode=none
 Type=simple

--- a/systemd/opentofu-runner.service
+++ b/systemd/opentofu-runner.service
@@ -3,5 +3,7 @@ PartOf=opentofu-runner.target
 [Install]
 WantedBy=opentofu-runner.target
 [Service]
-ExecStart=/usr/bin/ruby -e 'sleep'
+ExecStart=/usr/bin/ruby -e sleep
+Type=simple
+Restart=always
 Slice=manageiq.slice

--- a/systemd/opentofu-runner.service
+++ b/systemd/opentofu-runner.service
@@ -6,7 +6,7 @@ WantedBy=opentofu-runner.target
 User=manageiq
 Group=manageiq
 ExecStartPre=/bin/rm -f /tmp/%n.cid
-ExecStart=/usr/bin/podman run --conmon-pidfile %T/%N.pid --cidfile %T/%N.cid --cgroup-manager=cgroupfs --cgroups=no-conmon --log-driver=journald --name=opentofu-runner docker.io/manageiq/opentofu-runner:latest
+ExecStart=/usr/bin/podman run --conmon-pidfile %T/%N.pid --cidfile %T/%N.cid --cgroup-manager=cgroupfs --cgroups=no-conmon --log-driver=journald --name=opentofu-runner --secret=opentofu-runner-secret docker.io/manageiq/opentofu-runner:latest
 ExecStop=/usr/bin/podman stop --ignore -t 30 --cidfile %T/%N.cid --cgroup-manager=cgroupfs
 ExecStopPost=/usr/bin/podman rm --ignore --cidfile %T/%N.cid --cgroup-manager=cgroupfs
 ExecStopPost=/usr/bin/rm -f %T/%N.pid %T/%N.cid

--- a/systemd/opentofu-runner.service
+++ b/systemd/opentofu-runner.service
@@ -6,7 +6,7 @@ WantedBy=opentofu-runner.target
 User=manageiq
 Group=manageiq
 ExecStartPre=/bin/rm -f /tmp/%n.cid
-ExecStart=/usr/bin/podman run --conmon-pidfile %T/%N.pid --cidfile %T/%N.cid --cgroup-manager=cgroupfs --cgroups=no-conmon --log-driver=journald --name=opentofu-runner --secret=opentofu-runner-secret --root=/var/www/miq/vmdb/data/containers/storage docker.io/manageiq/opentofu-runner:latest
+ExecStart=/usr/bin/podman run --conmon-pidfile %T/%N.pid --cidfile %T/%N.cid --cgroup-manager=cgroupfs --cgroups=no-conmon --log-driver=journald --replace --name=opentofu-runner --secret=opentofu-runner-secret --root=/var/www/miq/vmdb/data/containers/storage docker.io/manageiq/opentofu-runner:latest
 ExecStop=/usr/bin/podman stop --ignore -t 30 --cidfile %T/%N.cid --cgroup-manager=cgroupfs --root=/var/www/miq/vmdb/data/containers/storage
 ExecStopPost=/usr/bin/podman rm --ignore --cidfile %T/%N.cid --cgroup-manager=cgroupfs --root=/var/www/miq/vmdb/data/containers/storage
 ExecStopPost=/usr/bin/rm -f %T/%N.pid %T/%N.cid

--- a/systemd/opentofu-runner.target
+++ b/systemd/opentofu-runner.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=manageiq.target


### PR DESCRIPTION
Adds an opentofu worker using the embedded_terraform role, note this will be the first non-ruby worker we'll have :tada:

TODO:
- [x] systemd service definition
- [x] check miq_worker status set to started
- [x] Pass environment variables for memcached / postgresql
- [x] Provide db password via podman/k8s secret
- [x] miq_worker record deleted when worker exits https://github.com/ManageIQ/manageiq/pull/22941
- [x] podified deployment definition https://github.com/ManageIQ/manageiq-pods/pull/1067

Dependents:
- [x] rpm_spec updates https://github.com/ManageIQ/manageiq-rpm_build/pull/450


<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
