### PR TITLE
Add methods to run Terraform Templates using TerraformRunner container APIs

### DIFF
--- a/lib/terraform/runner.rb
+++ b/lib/terraform/runner.rb
@@ -83,12 +83,11 @@ module Terraform
       private
 
       def server_url
-        ENV['TERRAFORM_RUNNER_URL'] || 'https://localhost:27000'
+        ENV['TERRAFORM_RUNNER_URL'] || 'https://opentofu-runner:27000'
       end
 
       def server_token
-        # TODO: fix hardcoded token
-        ENV['TERRAFORM_RUNNER_TOKEN'] || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IlNodWJoYW5naSBTaW5naCIsImlhdCI6MTcwNjAwMDk0M30.46mL8RRxfHI4yveZ2wTsHyF7s2BAiU84aruHBoz2JRQ'
+        ENV.fetch('TERRAFORM_RUNNER_TOKEN', nil)
       end
 
       def stack_job_interval_in_secs

--- a/lib/terraform/runner.rb
+++ b/lib/terraform/runner.rb
@@ -83,7 +83,7 @@ module Terraform
       private
 
       def server_url
-        ENV['TERRAFORM_RUNNER_URL'] || 'https://opentofu-runner:27000'
+        ENV.fetch('TERRAFORM_RUNNER_URL', 'https://opentofu-runner:27000')
       end
 
       def server_token
@@ -91,15 +91,11 @@ module Terraform
       end
 
       def stack_job_interval_in_secs
-        ENV['TERRAFORM_RUNNER_STACK_JOB_CHECK_INTERVAL'].to_i
-      rescue
-        10
+        ENV.fetch('TERRAFORM_RUNNER_STACK_JOB_CHECK_INTERVAL', 10).to_i
       end
 
       def stack_job_max_time_in_secs
-        ENV['TERRAFORM_RUNNER_STACK_JOB_MAX_TIME'].to_i
-      rescue
-        120
+        ENV.fetch('TERRAFORM_RUNNER_STACK_JOB_MAX_TIME', 120).to_i
       end
 
       # Create to paramaters as used by terraform-runner api

--- a/lib/terraform/runner.rb
+++ b/lib/terraform/runner.rb
@@ -1,0 +1,227 @@
+require 'rest-client'
+require 'timeout'
+require 'tempfile'
+require 'zip'
+require 'base64'
+
+module Terraform
+  class Runner
+    class << self
+      def server_url
+        ENV['TERRAFORM_RUNNER_URL'] || 'https://localhost:27000'
+      end
+
+      def server_token
+        # TODO: fix hardcoded token
+        ENV['TERRAFORM_RUNNER_TOKEN'] || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IlNodWJoYW5naSBTaW5naCIsImlhdCI6MTcwNjAwMDk0M30.46mL8RRxfHI4yveZ2wTsHyF7s2BAiU84aruHBoz2JRQ'
+      end
+
+      # Run a template, initiate stack creation (does wait to complete), via terraform-runner api
+      #
+      # @param input_vars [Hash] Hash with key/value pairs that will be passed as input variables to the
+      #        terraform-runner run
+      # @param template_path [String] Path to the template we will want to run
+      # @param tags [Hash] Hash with key/values pairs that will be passed as tags to the terraform-runner run
+      # @param credentials [Array] List of Authentication object ids to provide to the terraform run
+      # @param env_vars [Hash] Hash with key/value pairs that will be passed as environment variables to the
+      #        terraform-runner run
+      # @return [Terraform::Runner::ResponseAsync] Response object of terraform-runner create action
+      def run_async(input_vars, template_path, tags: nil, credentials: [], env_vars: {})
+        _log.info("In run_aysnc with #{template_path}")
+        response = run_create_stack(
+          template_path,
+          :input_vars  => input_vars,
+          :tags        => tags,
+          :credentials => credentials,
+          :env_vars    => env_vars
+        )
+        Terraform::Runner::ResponseAsync.new(response)
+      end
+
+      # Runs a template, wait until it completes ,via terraform-runner api
+      #
+      # @param input_vars [Hash] Hash with key/value pairs that will be passed as input variables to the
+      #        terraform-runner run
+      # @param template_path [String] Path to the template we will want to run
+      # @param tags [Hash] Hash with key/values pairs that will be passed as tags to the terraform-runner run
+      # @param credentials [Array] List of Authentication object ids to provide to the terraform run
+      # @param env_vars [Hash] Hash with key/value pairs that will be passed as environment variables to the
+      #        terraform-runner run
+      # @return [Terraform::Runner::Response] Response object with final result of terraform run
+      def run(input_vars, template_path, tags: nil, credentials: [], env_vars: {})
+        _log.info("In run")
+        run_create_stack_and_wait_until_completes(
+          template_path,
+          :input_vars  => input_vars,
+          :tags        => tags,
+          :credentials => credentials,
+          :env_vars    => env_vars
+        )
+      end
+
+      def terraform_runner_client
+        # TODO: verify ssl
+        verify_ssl = false
+
+        RestClient::Resource.new(
+          server_url,
+          :headers    => {:authorization => "Bearer #{server_token}"},
+          :verify_ssl => verify_ssl
+        )
+      end
+
+      def available?
+        return @available if defined?(@available)
+
+        response = terraform_runner_client['api/terraformjobs/count'].get
+        @available = response.code == 200
+      rescue
+        @available = false
+      end
+
+      # Run a template, initiate stack creation (does wait to complete), via terraform-runner api
+      #
+      # @param vars [Hash] Hash with key/value pairs that will be passed as input variables to the
+      #        terraform-runner run
+      # @return [Array] Array of {:name,:value}
+      def convert_to_cam_parameters(vars)
+        parameters = []
+        vars.each do |key, value|
+          parameters.push(
+            {
+              :name  => key,
+              :value => value
+            }
+          )
+        end
+      end
+
+      def run_create_stack(
+        template_path,
+        input_vars: [],
+        tags: nil,
+        credentials: [],
+        env_vars: {},
+        name: "stack-#{rand(36**8).to_s(36)}"
+      )
+        _log.info("In run_create_stack")
+        # TODO: fix hardcoded tenant_id
+        tenant_id = 'c158d710-d91c-11ed-9fee-d93323035b4e'
+
+        Tempfile.create(%w[opentofu-runner-payload .zip]) do |zip_file|
+          create_zip_file_from_directory(zip_file.path, template_path)
+          encoded_zip_file = Base64.encode64(File.binread(zip_file.path))
+
+          # TODO: use tags,env_vars
+          payload = JSON.generate(
+            {
+              :cloud_providers => credentials,
+              :name            => name,
+              :tenantId        => tenant_id,
+              :templateZipFile => encoded_zip_file,
+              :parameters      => convert_to_cam_parameters(input_vars)
+            }
+          )
+          _log.info("Payload:>\n, #{payload}")
+          http_response = terraform_runner_client['api/stack/create'].post(
+            payload, :content_type => 'application/json'
+          )
+          _log.info("==== http_response.body: \n #{http_response.body}")
+          _log.info("stack_job for template: #{template_path} running ...")
+          Terraform::Runner::Response.parsed_response(http_response)
+        end
+      end
+
+      def run_retrieve_stack_by_id(stack_id)
+        payload = JSON.generate(
+          {
+            :stack_id => stack_id
+          }
+        )
+        http_response = terraform_runner_client['api/stack/retrieve'].post(
+          payload, :content_type => 'application/json'
+        )
+        _log.info("==== http_response.body: \n #{http_response.body}")
+        Terraform::Runner::Response.parsed_response(http_response)
+      end
+
+      def wait_until_completes(stack_id)
+        interval_in_secs = 10
+        max_time_in_secs = 60
+
+        response = nil
+        Timeout.timeout(max_time_in_secs) do
+          _log.info("Starting wait for stack/#{stack_id} completes ...")
+          i = 0
+          loop do
+            _log.info(i)
+            i += 1
+
+            response = run_retrieve_stack_by_id(stack_id)
+
+            _log.info("status: #{response.status}")
+
+            case response.status
+            when "SUCCESS"
+              _log.info("Successful!")
+              break
+
+            when "FAILED"
+              _log.info("Failed!!")
+              _log.info(response.error_message)
+              break
+
+            when nil
+              _log.info("No status, must have failed, check response ...")
+              _log.info(response.message)
+              break
+            end
+            _log.info("============\n #{response.message} \n============")
+            _log.info("Sleep for #{interval_in_secs} secs")
+            sleep interval_in_secs
+
+            break if i >= 20
+          end
+          _log.info("loop ends: ran #{i} times")
+        end
+        response
+      end
+
+      def run_create_stack_and_wait_until_completes(
+        template_path,
+        input_vars: [],
+        tags: nil,
+        credentials: [],
+        env_vars: {},
+        name: "stack-#{rand(36**8).to_s(36)}"
+      )
+        _log.info("In run_create_stack_and_wait_until_completes")
+        response = run_create_stack(
+          template_path,
+          :input_vars  => input_vars,
+          :tags        => tags,
+          :credentials => credentials,
+          :env_vars    => env_vars,
+          :name        => name
+        )
+        wait_until_completes(response.stack_id)
+      end
+
+      def create_zip_file_from_directory(zip_file_path, template_path)
+        dir_path = template_path # directory to be zipped
+        dir_path = path[0...-1] if dir_path.end_with?('/')
+
+        _log.info("Create #{zip_file_path}")
+        Zip::File.open(zip_file_path, Zip::File::CREATE) do |zipfile|
+          Dir.chdir(dir_path)
+          Dir.glob("**/*").select { |fn| File.file?(fn) }.each do |file|
+            _log.info("Adding #{file}")
+            zipfile.add(file.sub("#{dir_path}/", ''), file)
+          end
+        end
+
+        zip_file_path
+      end
+    end
+  end
+end

--- a/lib/terraform/runner/response.rb
+++ b/lib/terraform/runner/response.rb
@@ -1,0 +1,56 @@
+require 'json'
+
+module Terraform
+  class Runner
+    class Response
+      include Vmdb::Logging
+
+      attr_reader :stack_id, :stack_name, :status, :action, :message, :error_message,
+                  :details, :created_at, :stack_job_start_time, :stack_job_end_time
+
+      # @return [String] Extracted attributes from the JSON response body object
+      def self.parsed_response(http_response)
+        data = JSON.parse(http_response.body)
+        _log.debug("data : #{data}")
+        Terraform::Runner::Response.new(
+          :stack_id             => data['stack_id'],
+          :stack_name           => data['stack_name'],
+          :status               => data['status'],
+          :action               => data['action'],
+          :message              => data['message'],
+          :error_message        => data['error_message'],
+          :details              => data['details'],
+          :created_at           => data['created_at'],
+          :stack_job_start_time => data['stack_job_start_time'],
+          :stack_job_end_time   => data['stack_job_end_time']
+        )
+      end
+
+      # Response object designed for holding full response from terraform-runner
+      #
+      # @param stack_id [String] terraform-runner stack instance id
+      # @param stack_name [String] name of the stack instance
+      # @param status [String] IN_PROGRESS/SUCCESS/FAILED
+      # @param action [String] action performed CREATE,DESTROY,etc
+      # @param message [String] Stdout from terraform-runner stack instance run
+      # @param error_message [String] Stderr from terraform-runner run instance run
+      # @param debug [Boolean] whether or not to delete base_dir after run (for debugging)
+      # @param details [Hash]
+      # @param created_at [String]
+      # @param stack_job_start_time [String]
+      # @param stack_job_end_time [String]
+      def initialize(stack_id:, stack_name: nil, status: nil, action: nil, message: nil, error_message: nil, details: nil, created_at: nil, stack_job_start_time: nil, stack_job_end_time: nil)
+        @stack_id      = stack_id
+        @stack_name    = stack_name
+        @status        = status
+        @action        = action
+        @message       = message
+        @error_message = error_message
+        @details       = details
+        @created_at    = created_at
+        @stack_job_start_time = stack_job_start_time
+        @stack_job_end_time   = stack_job_end_time
+      end
+    end
+  end
+end

--- a/lib/terraform/runner/response_async.rb
+++ b/lib/terraform/runner/response_async.rb
@@ -1,0 +1,28 @@
+module Terraform
+  class Runner
+    class ResponseAsync
+      include Vmdb::Logging
+
+      attr_reader :response, :debug
+
+      # Response object designed for holding full response from terraform-runner
+      #
+      # @param response [Object] Terraform::Runner::Response object
+      # @param debug [Boolean] whether or not to delete base_dir after run (for debugging)
+      def initialize(response, debug: false)
+        @response = response
+        @debug    = debug
+      end
+
+      # @return [Boolean] true if the terraform job is still running, false when it's finished
+      def running?
+        response.status == "IN_PROGRESS"
+      end
+
+      # Stops the running Terraform job
+      def stop
+        raise NotImplementedError, "Not yet impleted"
+      end
+    end
+  end
+end

--- a/lib/terraform/runner/response_async.rb
+++ b/lib/terraform/runner/response_async.rb
@@ -12,16 +12,19 @@ module Terraform
 
       # @return [Boolean] true if the terraform stack job is still running, false when it's finished
       def running?
-        return (@response.status == "" || @response.status == "IN_PROGRESS") if @response
+        return false if @response && completed?(@response.status)
 
-        false
+        # re-fetch response
+        refresh_response
+
+        !completed?(@response.status)
       end
 
       # Stops the running Terraform job
       def stop
-        raise Error, "Not yet running" if !running?
+        raise "No job running to stop" if !running?
 
-        Terraform::Runner.stop_async(@response.stack_id)
+        Terraform::Runner.stop_async(@stack_id)
       end
 
       # Re-Fetch async job's response
@@ -31,15 +34,33 @@ module Terraform
         @response
       end
 
-      # @return [Terraform::Runner::Response, NilClass] Response object with all details about the Terraform run, or nil
+      # # @return [Terraform::Runner::Response, NilClass] Response object with all details about the Terraform run, or nil
+      # #         if the Terraform is still running
+      # def response
+      #   return if running?
+      #
+      #   @response
+      # end
+
+      # @return [Terraform::Runner::Response] Response object with all details about the Terraform run, or nil
       #         if the Terraform is still running
       def response
-        # return if running?
-        return @response if @response
-
-        @response = Terraform::Runner.fetch_result_by_stack_id(@stack_id)
+        if running?
+          _log.info("terraform-runner job [#{@stack_id}] is still running ...")
+        end
 
         @response
+      end
+
+      private
+
+      def completed?(status)
+        case status.to_s.upcase
+        when "SUCCESS", "FAILED", "CANCELLED"
+          true
+        else
+          false
+        end
       end
     end
   end

--- a/spec/lib/terraform/runner/data/hello-world/main.tf
+++ b/spec/lib/terraform/runner/data/hello-world/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.1.0"
+}
+
+variable "name" {
+    type = string
+    default = "World"
+}
+
+resource "null_resource" "null_resource_simple" {
+    provisioner "local-exec" {
+        command = "echo Hello '${var.name}'"
+    }
+}
+
+output "greeting" {
+  value = "Hello ${var.name}!"
+}

--- a/spec/lib/terraform/runner/data/responses/hello-world-create-success.json
+++ b/spec/lib/terraform/runner/data/responses/hello-world-create-success.json
@@ -1,0 +1,9 @@
+{
+    "stack_id": "72259c10-e84c-11ee-a474-2d77bed8e73a",
+    "stack_job_id": 11,
+    "stack_job_is_latest": true,
+    "action": "CREATE",
+    "status": "IN_PROGRESS",
+    "stack_name": "test-hello-world",
+    "tenantId": "c158d710-d91c-11ed-9fee-d93323035b4e"
+}

--- a/spec/lib/terraform/runner/data/responses/hello-world-retrieve-success.json
+++ b/spec/lib/terraform/runner/data/responses/hello-world-retrieve-success.json
@@ -1,0 +1,39 @@
+{
+    "stack_id": "72259c10-e84c-11ee-a474-2d77bed8e73a",
+    "stack_job_id": 11,
+    "stack_job_is_latest": true,
+    "status": "SUCCESS",
+    "action": "CREATE",
+    "message": "Fri Mar 22 2024 13:02:32 GMT+0000 (Coordinated Universal Time) Running terraform init ... \n\n\u001b[0m\u001b[1mInitializing provider plugins...\u001b[0m\n- Finding latest version of hashicorp/null...\n- Installing hashicorp/null v3.2.2...\n- Installed hashicorp/null v3.2.2 (signed, key ID \u001b[0m\u001b[1m0C0AF313E5FD9F80\u001b[0m\u001b[0m)\n\nProviders are signed by their developers.\nIf you'd like to know more about provider signing, you can read about it here:\nhttps://opentofu.org/docs/cli/plugins/signing/\n\nOpenTofu has created a lock file \u001b[1m.terraform.lock.hcl\u001b[0m to record the provider\nselections it made above. Include this file in your version control repository\nso that OpenTofu can guarantee to make the same selections by default when\nyou run \"tofu init\" in the future.\u001b[0m\n\n\u001b[0m\u001b[1m\u001b[32mOpenTofu has been successfully initialized!\u001b[0m\u001b[32m\u001b[0m\n\u001b[0m\u001b[32m\nYou may now begin working with OpenTofu. Try running \"tofu plan\" to see\nany changes that are required for your infrastructure. All OpenTofu commands\nshould now work.\n\nIf you ever set or change modules or backend configuration for OpenTofu,\nrerun this command to reinitialize your working directory. If you forget, other\ncommands will detect it and remind you to do so if necessary.\u001b[0m\n\n\nFri Mar 22 2024 13:02:34 GMT+0000 (Coordinated Universal Time) Running terraform apply ... \n\nOpenTofu used the selected providers to generate the following execution\nplan. Resource actions are indicated with the following symbols:\n  \u001b[32m+\u001b[0m create\u001b[0m\n\nOpenTofu will perform the following actions:\n\n\u001b[1m  # null_resource.null_resource_simple\u001b[0m will be created\n\u001b[0m  \u001b[32m+\u001b[0m\u001b[0m resource \"null_resource\" \"null_resource_simple\" {\n      \u001b[32m+\u001b[0m\u001b[0m id = (known after apply)\n    }\n\n\u001b[1mPlan:\u001b[0m 1 to add, 0 to change, 0 to destroy.\n\u001b[0m\nChanges to Outputs:\n  \u001b[32m+\u001b[0m\u001b[0m greeting = \"Hello World\"\n\u001b[0m\u001b[1mnull_resource.null_resource_simple: Creating...\u001b[0m\u001b[0m\n\u001b[0m\u001b[1mnull_resource.null_resource_simple: Provisioning with 'local-exec'...\u001b[0m\u001b[0m\n\u001b[0m\u001b[1mnull_resource.null_resource_simple (local-exec):\u001b[0m \u001b[0mExecuting: [\"/bin/sh\" \"-c\" \"echo Hello World\"]\n\u001b[0m\u001b[1mnull_resource.null_resource_simple (local-exec):\u001b[0m \u001b[0mHello World\n\u001b[0m\u001b[1mnull_resource.null_resource_simple: Creation complete after 0s [id=5554222779043651614]\u001b[0m\n\u001b[0m\u001b[1m\u001b[32m\nApply complete! Resources: 1 added, 0 changed, 0 destroyed.\n\u001b[0m\u001b[0m\u001b[1m\u001b[32m\nOutputs:\n\n\u001b[0mgreeting = \"Hello World\"\n",
+    "error_message": "",
+    "details": {
+      "resources": [
+        {
+          "name": "null_resource.null_resource_simple",
+          "consolelinks": [],
+          "details": {
+            "id": "5554222779043651614",
+            "triggers": null
+          },
+          "tainted": false,
+          "idFromProvider": "5554222779043651614",
+          "typeFromProvider": "null_resource",
+          "type": "unknown",
+          "provider": "unknown"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "greeting",
+          "type": "string",
+          "value": "Hello World"
+        }
+      ]
+    },
+    "stack_name": "test-hello-world",
+    "created_at": "2024-03-22T13:02:32.537Z",
+    "metadata": null,
+    "stack_job_start_time": "2024-03-22T13:02:32.537Z",
+    "stack_job_end_time": "2024-03-22T13:02:36.555Z"
+  }
+  

--- a/spec/lib/terraform/runner_spec.rb
+++ b/spec/lib/terraform/runner_spec.rb
@@ -21,89 +21,6 @@ RSpec.describe(Terraform::Runner) do
     end
   end
 
-  describe ".run hello-world with no input vars ( nil argument )" do
-    let(:input_vars) { nil }
-
-    before do
-      ENV["TERRAFORM_RUNNER_URL"] = "https://1.2.3.4:7000"
-
-      stub_request(:post, "https://1.2.3.4:7000/api/stack/create")
-        .with(:body => hash_including({:parameters => []}))
-        .to_return(
-          :status => 200,
-          :body   => @hello_world_create_response.to_json
-        )
-
-      stub_request(:post, "https://1.2.3.4:7000/api/stack/retrieve")
-        .with(:body => hash_including({:stack_id => @hello_world_retrieve_response['stack_id']}))
-        .to_return(
-          :status => 200,
-          :body   => @hello_world_retrieve_response.to_json
-        )
-    end
-
-    it "runs a hello-world terraform template" do
-      response = Terraform::Runner.run(input_vars, File.join(__dir__, "runner/data/hello-world"))
-
-      expect(response.status).to(eq('SUCCESS'), "terraform-runner failed with:\n#{response.status}")
-      expect(response.message).to(include('greeting = "Hello World"'))
-      expect(response.stack_id).to(eq(@hello_world_retrieve_response['stack_id']))
-      expect(response.action).to(eq('CREATE'))
-      expect(response.stack_name).to(eq(@hello_world_retrieve_response['stack_name']))
-      expect(response.details.keys).to(eq(%w[resources outputs]))
-    end
-  end
-
-  describe ".run hello-world with input_vars" do
-    let(:input_vars) { {:name => 'Mumbai'} }
-
-    def verify_request_and_respond(request)
-      body = JSON.parse(request.body)
-
-      # verify parameters
-      expect(body['parameters'].length).to(eq(1))
-      data = body['parameters'][0]
-      expect(data['name']).to(eq('name'))
-      expect(data['value']).to(eq('Mumbai'))
-
-      # verify other attributes
-      expect(body['name']).not_to(be_empty)
-      expect(body['tenantId']).not_to(be_empty)
-      expect(body['templateZipFile']).not_to(be_empty)
-
-      @hello_world_create_response.to_json
-    end
-
-    before do
-      ENV["TERRAFORM_RUNNER_URL"] = "https://1.2.3.4:7000"
-
-      stub_request(:post, "https://1.2.3.4:7000/api/stack/create")
-        .to_return(->(request) { {:body => verify_request_and_respond(request)} })
-
-      response = @hello_world_retrieve_response.clone
-      response['message'] = response['message'].gsub('World', 'Mumbai')
-      response['details']['outputs'][0]['value'] = response['details']['outputs'][0]['value'].sub('World', 'Mumbai')
-
-      stub_request(:post, "https://1.2.3.4:7000/api/stack/retrieve")
-        .with(:body => hash_including({:stack_id => @hello_world_retrieve_response['stack_id']}))
-        .to_return(
-          :status => 200,
-          :body   => response.to_json
-        )
-    end
-
-    it "runs a hello-world terraform template" do
-      response = Terraform::Runner.run(input_vars, File.join(__dir__, "runner/data/hello-world"))
-
-      expect(response.status).to(eq('SUCCESS'), "terraform-runner failed with:\n#{response.status}")
-      expect(response.message).to(include('greeting = "Hello Mumbai"'))
-      expect(response.stack_id).to(eq(@hello_world_retrieve_response['stack_id']))
-      expect(response.action).to(eq('CREATE'))
-      expect(response.stack_name).to(eq(@hello_world_retrieve_response['stack_name']))
-      expect(response.details.keys).to(eq(%w[resources outputs]))
-    end
-  end
-
   context '.run_async hello-world' do
     describe '.run_async' do
       create_stub = nil
@@ -142,7 +59,10 @@ RSpec.describe(Terraform::Runner) do
         expect(response.stack_name).to(eq(@hello_world_create_response['stack_name']))
         expect(response.message).to(be_nil)
         expect(response.details).to(be_nil)
+      end
 
+      it "is aliased as run" do
+        expect(Terraform::Runner.method(:run)).to eq(Terraform::Runner.method(:run_async))
       end
     end
 

--- a/spec/lib/terraform/runner_spec.rb
+++ b/spec/lib/terraform/runner_spec.rb
@@ -1,0 +1,51 @@
+require 'webmock/rspec'
+require 'json'
+
+RSpec.describe(Terraform::Runner) do
+  describe "is .available" do
+    before do
+      ENV["TERRAFORM_RUNNER_URL"] = "https://1.2.3.4:7000"
+
+      stub_request(:get, "https://1.2.3.4:7000/api/terraformjobs/count")
+        .to_return(:status => 200, :body => {'count' => 0}.to_json)
+    end
+
+    it "check if terraform-runner service is available" do
+      expect(Terraform::Runner.available?).to(be(true))
+    end
+  end
+
+  describe ".run" do
+    let(:input_vars) { {} }
+
+    let(:create_response) { JSON.parse(File.read(File.join(__dir__, "runner/data/responses/hello-world-create-success.json"))) }
+    let(:retrieve_response) { JSON.parse(File.read(File.join(__dir__, "runner/data/responses/hello-world-retrieve-success.json"))) }
+
+    before do
+      ENV["TERRAFORM_RUNNER_URL"] = "https://1.2.3.4:7000"
+
+      stub_request(:post, "https://1.2.3.4:7000/api/stack/create")
+        .to_return(
+          :status => 200,
+          :body   => create_response.to_json
+        )
+
+      stub_request(:post, "https://1.2.3.4:7000/api/stack/retrieve")
+        .to_return(
+          :status => 200,
+          :body   => retrieve_response.to_json
+        )
+    end
+
+    it "runs a hello-world terraform template" do
+      response = Terraform::Runner.run(input_vars, File.join(__dir__, "runner/data/hello-world"))
+
+      expect(response.status).to(eq('SUCCESS'), "terraform-runner failed with:\n#{response.status}")
+      expect(response.message).to(include('greeting = "Hello World"'))
+      expect(response.stack_id).to(eq(retrieve_response['stack_id']))
+      expect(response.action).to(eq('CREATE'))
+      expect(response.stack_name).to(eq(retrieve_response['stack_name']))
+      expect(response.details.keys).to(eq(%w[resources outputs]))
+    end
+  end
+end

--- a/spec/lib/terraform/runner_spec.rb
+++ b/spec/lib/terraform/runner_spec.rb
@@ -20,19 +20,21 @@ RSpec.describe(Terraform::Runner) do
     end
   end
 
-  describe ".run hello-world" do
-    let(:input_vars) { {} }
+  describe ".run hello-world with no input vars ( nil argument )" do
+    let(:input_vars) { nil }
 
     before do
       ENV["TERRAFORM_RUNNER_URL"] = "https://1.2.3.4:7000"
 
       stub_request(:post, "https://1.2.3.4:7000/api/stack/create")
+        .with(:body => hash_including({:parameters => []}))
         .to_return(
           :status => 200,
           :body   => @hello_world_create_response.to_json
         )
 
       stub_request(:post, "https://1.2.3.4:7000/api/stack/retrieve")
+        .with(:body => hash_including({:stack_id => @hello_world_retrieve_response['stack_id']}))
         .to_return(
           :status => 200,
           :body   => @hello_world_retrieve_response.to_json
@@ -51,6 +53,56 @@ RSpec.describe(Terraform::Runner) do
     end
   end
 
+  describe ".run hello-world with input_vars" do
+    let(:input_vars) { {:name => 'Mumbai'} }
+
+    def verify_request_and_respond(request)
+      body = JSON.parse(request.body)
+
+      # verify parameters
+      expect(body['parameters'].length).to(eq(1))
+      data = body['parameters'][0]
+      expect(data['name']).to(eq('name'))
+      expect(data['value']).to(eq('Mumbai'))
+
+      # verify other attributes
+      expect(body['name']).not_to(be_empty)
+      expect(body['tenantId']).not_to(be_empty)
+      expect(body['templateZipFile']).not_to(be_empty)
+
+      @hello_world_create_response.to_json
+    end
+
+    before do
+      ENV["TERRAFORM_RUNNER_URL"] = "https://1.2.3.4:7000"
+
+      stub_request(:post, "https://1.2.3.4:7000/api/stack/create")
+        .to_return(->(request) { {:body => verify_request_and_respond(request)} })
+
+      response = @hello_world_retrieve_response.clone
+      response['message'] = response['message'].gsub('World', 'Mumbai')
+      response['details']['outputs'][0]['value'] = response['details']['outputs'][0]['value'].sub('World', 'Mumbai')
+
+      stub_request(:post, "https://1.2.3.4:7000/api/stack/retrieve")
+        .with(:body => hash_including({:stack_id => @hello_world_retrieve_response['stack_id']}))
+        .to_return(
+          :status => 200,
+          :body   => response.to_json
+        )
+    end
+
+    it "runs a hello-world terraform template" do
+      response = Terraform::Runner.run(input_vars, File.join(__dir__, "runner/data/hello-world"))
+
+      expect(response.status).to(eq('SUCCESS'), "terraform-runner failed with:\n#{response.status}")
+      expect(response.message).to(include('greeting = "Hello Mumbai"'))
+      expect(response.stack_id).to(eq(@hello_world_retrieve_response['stack_id']))
+      expect(response.action).to(eq('CREATE'))
+      expect(response.stack_name).to(eq(@hello_world_retrieve_response['stack_name']))
+      expect(response.details.keys).to(eq(%w[resources outputs]))
+    end
+  end
+
   context '.run_async hello-world' do
     describe '.run_async' do
       create_stub = nil
@@ -60,12 +112,14 @@ RSpec.describe(Terraform::Runner) do
         ENV["TERRAFORM_RUNNER_URL"] = "https://1.2.3.4:7000"
 
         create_stub = stub_request(:post, "https://1.2.3.4:7000/api/stack/create")
+                      .with(:body => hash_including({:parameters => []}))
                       .to_return(
                         :status => 200,
                         :body   => @hello_world_create_response.to_json
                       )
 
         retrieve_stub = stub_request(:post, "https://1.2.3.4:7000/api/stack/retrieve")
+                        .with(:body => hash_including({:stack_id => @hello_world_retrieve_response['stack_id']}))
                         .to_return(
                           :status => 200,
                           :body   => @hello_world_create_response.to_json
@@ -97,6 +151,7 @@ RSpec.describe(Terraform::Runner) do
         ENV["TERRAFORM_RUNNER_URL"] = "https://1.2.3.4:7000"
 
         retrieve_stub = stub_request(:post, "https://1.2.3.4:7000/api/stack/retrieve")
+                        .with(:body => hash_including({:stack_id => @hello_world_retrieve_response['stack_id']}))
                         .to_return(
                           :status => 200,
                           :body   => @hello_world_retrieve_response.to_json
@@ -127,6 +182,7 @@ RSpec.describe(Terraform::Runner) do
         ENV["TERRAFORM_RUNNER_URL"] = "https://1.2.3.4:7000"
 
         create_stub = stub_request(:post, "https://1.2.3.4:7000/api/stack/create")
+                      .with(:body => hash_including({:parameters => []}))
                       .to_return(
                         :status => 200,
                         :body   => @hello_world_create_response.to_json
@@ -136,6 +192,7 @@ RSpec.describe(Terraform::Runner) do
         cancel_response[:status] = 'CANCELLED'
 
         retrieve_stub = stub_request(:post, "https://1.2.3.4:7000/api/stack/retrieve")
+                        .with(:body => hash_including({:stack_id => @hello_world_retrieve_response['stack_id']}))
                         .to_return(
                           :status => 200,
                           :body   => @hello_world_create_response.to_json
@@ -146,6 +203,7 @@ RSpec.describe(Terraform::Runner) do
                           :body   => cancel_response.to_json
                         )
         cancel_stub = stub_request(:post, "https://1.2.3.4:7000/api/stack/cancel")
+                      .with(:body => hash_including({:stack_id => @hello_world_retrieve_response['stack_id']}))
                       .to_return(
                         :status => 200,
                         :body   => cancel_response.to_json

--- a/spec/lib/terraform/runner_spec.rb
+++ b/spec/lib/terraform/runner_spec.rb
@@ -2,6 +2,11 @@ require 'webmock/rspec'
 require 'json'
 
 RSpec.describe(Terraform::Runner) do
+  before(:all) do
+    @hello_world_create_response = JSON.parse(File.read(File.join(__dir__, "runner/data/responses/hello-world-create-success.json")))
+    @hello_world_retrieve_response = JSON.parse(File.read(File.join(__dir__, "runner/data/responses/hello-world-retrieve-success.json")))
+  end
+
   describe "is .available" do
     before do
       ENV["TERRAFORM_RUNNER_URL"] = "https://1.2.3.4:7000"
@@ -15,11 +20,8 @@ RSpec.describe(Terraform::Runner) do
     end
   end
 
-  describe ".run" do
+  describe ".run hello-world" do
     let(:input_vars) { {} }
-
-    let(:create_response) { JSON.parse(File.read(File.join(__dir__, "runner/data/responses/hello-world-create-success.json"))) }
-    let(:retrieve_response) { JSON.parse(File.read(File.join(__dir__, "runner/data/responses/hello-world-retrieve-success.json"))) }
 
     before do
       ENV["TERRAFORM_RUNNER_URL"] = "https://1.2.3.4:7000"
@@ -27,13 +29,13 @@ RSpec.describe(Terraform::Runner) do
       stub_request(:post, "https://1.2.3.4:7000/api/stack/create")
         .to_return(
           :status => 200,
-          :body   => create_response.to_json
+          :body   => @hello_world_create_response.to_json
         )
 
       stub_request(:post, "https://1.2.3.4:7000/api/stack/retrieve")
         .to_return(
           :status => 200,
-          :body   => retrieve_response.to_json
+          :body   => @hello_world_retrieve_response.to_json
         )
     end
 
@@ -42,56 +44,141 @@ RSpec.describe(Terraform::Runner) do
 
       expect(response.status).to(eq('SUCCESS'), "terraform-runner failed with:\n#{response.status}")
       expect(response.message).to(include('greeting = "Hello World"'))
-      expect(response.stack_id).to(eq(retrieve_response['stack_id']))
+      expect(response.stack_id).to(eq(@hello_world_retrieve_response['stack_id']))
       expect(response.action).to(eq('CREATE'))
-      expect(response.stack_name).to(eq(retrieve_response['stack_name']))
+      expect(response.stack_name).to(eq(@hello_world_retrieve_response['stack_name']))
       expect(response.details.keys).to(eq(%w[resources outputs]))
     end
   end
 
-  describe ".run_async" do
-    let(:input_vars) { {} }
+  context '.run_async hello-world' do
+    describe '.run_async' do
+      create_stub = nil
+      retrieve_stub = nil
 
-    let(:create_response) { JSON.parse(File.read(File.join(__dir__, "runner/data/responses/hello-world-create-success.json"))) }
-    let(:retrieve_response) { JSON.parse(File.read(File.join(__dir__, "runner/data/responses/hello-world-retrieve-success.json"))) }
+      before do
+        ENV["TERRAFORM_RUNNER_URL"] = "https://1.2.3.4:7000"
 
-    before do
-      ENV["TERRAFORM_RUNNER_URL"] = "https://1.2.3.4:7000"
+        create_stub = stub_request(:post, "https://1.2.3.4:7000/api/stack/create")
+                      .to_return(
+                        :status => 200,
+                        :body   => @hello_world_create_response.to_json
+                      )
 
-      stub_request(:post, "https://1.2.3.4:7000/api/stack/create")
-        .to_return(
-          :status => 200,
-          :body   => create_response.to_json
-        )
+        retrieve_stub = stub_request(:post, "https://1.2.3.4:7000/api/stack/retrieve")
+                        .to_return(
+                          :status => 200,
+                          :body   => @hello_world_create_response.to_json
+                        )
+      end
 
-      stub_request(:post, "https://1.2.3.4:7000/api/stack/retrieve")
-        .to_return(
-          :status => 200,
-          :body   => retrieve_response.to_json
-        )
+      let(:input_vars) { {} }
+
+      it "start running hello-world terraform template" do
+        async_response = Terraform::Runner.run_async(input_vars, File.join(__dir__, "runner/data/hello-world"))
+        response = async_response.response
+
+        expect(response.status).to(eq('IN_PROGRESS'), "terraform-runner failed with:\n#{response.status}")
+        expect(response.stack_id).to(eq(@hello_world_create_response['stack_id']))
+        expect(response.action).to(eq('CREATE'))
+        expect(response.stack_name).to(eq(@hello_world_create_response['stack_name']))
+        expect(response.message).to(be_nil)
+        expect(response.details).to(be_nil)
+
+        expect(create_stub).to(have_been_requested.times(1))
+        expect(retrieve_stub).to(have_been_requested.times(1))
+      end
     end
 
-    it "initiates running of hello-world terraform template" do
-      async_response = Terraform::Runner.run_async(input_vars, File.join(__dir__, "runner/data/hello-world"))
-      response = async_response.response
+    describe 'ResponseAsync' do
+      retrieve_stub = nil
 
-      expect(response.status).to(eq('IN_PROGRESS'), "terraform-runner failed with:\n#{response.status}")
-      expect(response.stack_id).to(eq(create_response['stack_id']))
-      expect(response.action).to(eq('CREATE'))
-      expect(response.stack_name).to(eq(create_response['stack_name']))
-      expect(response.message).to(be_nil)
-      expect(response.details).to(be_nil)
+      before do
+        ENV["TERRAFORM_RUNNER_URL"] = "https://1.2.3.4:7000"
+
+        retrieve_stub = stub_request(:post, "https://1.2.3.4:7000/api/stack/retrieve")
+                        .to_return(
+                          :status => 200,
+                          :body   => @hello_world_retrieve_response.to_json
+                        )
+      end
+
+      it "retrieve hello-world completed result" do
+        async_response = Terraform::Runner::ResponseAsync.new(@hello_world_create_response['stack_id'])
+        response = async_response.response
+
+        expect(response.status).to(eq('SUCCESS'), "terraform-runner failed with:\n#{response.status}")
+        expect(response.message).to(include('greeting = "Hello World"'))
+        expect(response.stack_id).to(eq(@hello_world_retrieve_response['stack_id']))
+        expect(response.action).to(eq('CREATE'))
+        expect(response.stack_name).to(eq(@hello_world_retrieve_response['stack_name']))
+        expect(response.details.keys).to(eq(%w[resources outputs]))
+
+        expect(retrieve_stub).to(have_been_requested.times(1))
+      end
     end
 
-    it "retrieve result run_async job" do
-      response = Terraform::Runner.fetch_result_by_stack_id(create_response['stack_id'])
+    describe 'Stop running .run_async template job' do
+      create_stub = nil
+      retrieve_stub = nil
+      cancel_stub = nil
 
-      expect(response.status).to(eq('SUCCESS'), "terraform-runner failed with:\n#{response.status}")
-      expect(response.message).to(include('greeting = "Hello World"'))
-      expect(response.stack_id).to(eq(retrieve_response['stack_id']))
-      expect(response.action).to(eq('CREATE'))
-      expect(response.stack_name).to(eq(retrieve_response['stack_name']))
-      expect(response.details.keys).to(eq(%w[resources outputs]))
+      before do
+        ENV["TERRAFORM_RUNNER_URL"] = "https://1.2.3.4:7000"
+
+        create_stub = stub_request(:post, "https://1.2.3.4:7000/api/stack/create")
+                      .to_return(
+                        :status => 200,
+                        :body   => @hello_world_create_response.to_json
+                      )
+
+        cancel_response = @hello_world_create_response.clone
+        cancel_response[:status] = 'CANCELLED'
+
+        retrieve_stub = stub_request(:post, "https://1.2.3.4:7000/api/stack/retrieve")
+                        .to_return(
+                          :status => 200,
+                          :body   => @hello_world_create_response.to_json
+                        )
+                        .then
+                        .to_return(
+                          :status => 200,
+                          :body   => cancel_response.to_json
+                        )
+        cancel_stub = stub_request(:post, "https://1.2.3.4:7000/api/stack/cancel")
+                      .to_return(
+                        :status => 200,
+                        :body   => cancel_response.to_json
+                      )
+      end
+
+      let(:input_vars) { {} }
+
+      it "start running, then stop the before it completes" do
+        async_response = Terraform::Runner.run_async(input_vars, File.join(__dir__, "runner/data/hello-world"))
+        response = async_response.response
+
+        expect(response.status).to(eq('IN_PROGRESS'), "terraform-runner failed with:\n#{response.status}")
+        expect(response.stack_id).to(eq(@hello_world_create_response['stack_id']))
+        expect(response.action).to(eq('CREATE'))
+        expect(response.stack_name).to(eq(@hello_world_create_response['stack_name']))
+        expect(response.message).to(be_nil)
+        expect(response.details).to(be_nil)
+
+        expect(create_stub).to(have_been_requested.times(1))
+        expect(retrieve_stub).to(have_been_requested.times(1))
+
+        # Stop the job terraform-runner
+        async_response.stop
+        expect(cancel_stub).to(have_been_requested.times(1))
+
+        # Re-fetch latest response
+        async_response.refresh_response
+        response = async_response.response
+
+        expect(response.status).to(eq('CANCELLED'), "terraform-runner failed with:\n#{response.status}")
+        expect(retrieve_stub).to(have_been_requested.times(2))
+      end
     end
   end
 end

--- a/spec/lib/terraform/runner_spec.rb
+++ b/spec/lib/terraform/runner_spec.rb
@@ -3,6 +3,7 @@ require 'json'
 
 RSpec.describe(Terraform::Runner) do
   before(:all) do
+    ENV["TERRAFORM_RUNNER_TOKEN"] = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IlNodWJoYW5naSBTaW5naCIsImlhdCI6MTcwNjAwMDk0M30.46mL8RRxfHI4yveZ2wTsHyF7s2BAiU84aruHBoz2JRQ'
     @hello_world_create_response = JSON.parse(File.read(File.join(__dir__, "runner/data/responses/hello-world-create-success.json")))
     @hello_world_retrieve_response = JSON.parse(File.read(File.join(__dir__, "runner/data/responses/hello-world-retrieve-success.json")))
   end


### PR DESCRIPTION
* Add `run` method to run terraform templates in async mode
* Add `run_async` method to run terraform templates
* `Response` class to represent TerraformRunner-Stack API response
* `ResponseAsync` class with `stop` method to cancel a TerraformRunner-Stack API Job. 
* Add spec the test terraform-runner methods

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
