### PR TITLE
Add Embedded Terraform credential type

### DIFF
--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/credential.rb
@@ -1,2 +1,5 @@
 class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Credential < ManageIQ::Providers::EmbeddedAutomationManager::Authentication
+  def self.credential_type
+    "embedded_terraform_credential_types"
+  end
 end


### PR DESCRIPTION
This is needed to make credential types pluggable. This will also be needed for https://github.com/ManageIQ/manageiq-providers-embedded_terraform/pull/3

Needed for:
- [ ] https://github.com/ManageIQ/manageiq/pull/22995
- [ ] https://github.com/ManageIQ/manageiq-providers-embedded_terraform/pull/3

@miq-bot assign @agrare 
@miq-bot add_reviewer @agrare 
@miq-bot add_label enhancement