### PR TITLE
Fix repository refresh button

### DIFF
--- a/app/controllers/embedded_terraform_repository_controller.rb
+++ b/app/controllers/embedded_terraform_repository_controller.rb
@@ -34,6 +34,8 @@ class EmbeddedTerraformRepositoryController < ApplicationController
 
   def button
     case params[:pressed]
+    when 'embedded_configuration_script_source_refresh'
+      repository_refresh
     when "embedded_configuration_script_source_edit"
       id = params[:miq_grid_checks]
       javascript_redirect(:action => 'edit', :id => id)


### PR DESCRIPTION
Fixed an issue where the repository refresh button was not working.

<img width="1410" alt="Screenshot 2024-04-25 at 12 06 05 PM" src="https://github.com/ManageIQ/manageiq-providers-embedded_terraform/assets/32444791/b3cf136d-419e-42ef-ac08-a3ac0a2e36cc">
