### PR TITLE
Add new table columns for templates and repositories

### DIFF
--- a/product/views/ManageIQ_Providers_EmbeddedTerraform_AutomationManager_ConfigurationScriptSource.yaml
+++ b/product/views/ManageIQ_Providers_EmbeddedTerraform_AutomationManager_ConfigurationScriptSource.yaml
@@ -22,6 +22,8 @@ cols:
 - name
 - description
 - total_payloads
+- scm_url
+- scm_branch
 - created_at
 - updated_at
 - status
@@ -35,6 +37,8 @@ col_order:
 - name
 - description
 - total_payloads
+- scm_url
+- scm_branch
 - created_at
 - updated_at
 - status
@@ -44,6 +48,8 @@ headers:
 - Name
 - Description
 - Templates
+- Repository URL
+- Repository Branch
 - Created On
 - Last refresh on
 - Status

--- a/product/views/ManageIQ_Providers_EmbeddedTerraform_AutomationManager_Template.yaml
+++ b/product/views/ManageIQ_Providers_EmbeddedTerraform_AutomationManager_Template.yaml
@@ -23,6 +23,7 @@ cols:
 - name
 - description
 - repository
+- configuration_script_source.scm_branch
 - created_at
 - updated_at
 
@@ -31,12 +32,14 @@ include:
   configuration_script_source:
     columns:
     - name
+    - scm_branch
 
 # Order of columns (from all tables)
 col_order:
 - name
 - description
 - configuration_script_source.name
+- configuration_script_source.scm_branch
 - created_at
 - updated_at
 
@@ -45,6 +48,7 @@ headers:
 - Name
 - Description
 - Repository
+- Repository Branch
 - Created On
 - Updated On
 


### PR DESCRIPTION
Added new table columns for the Templates and Repositories table screens.

For the Templates table this pr adds the scm_branch column to show the Repository Branch.

For the Repositories table this pr adds the scm_url and scm_branch columns to show the Repository URL and Repository Branch.

Before:
<img width="1401" alt="Screenshot 2024-04-26 at 10 33 07 AM" src="https://github.com/ManageIQ/manageiq-providers-embedded_terraform/assets/32444791/fd7a0c2c-4869-462a-88f0-c160b2f10213">
<img width="1424" alt="Screenshot 2024-04-26 at 10 33 17 AM" src="https://github.com/ManageIQ/manageiq-providers-embedded_terraform/assets/32444791/04698b36-20e9-4af7-a1ba-9a1767eac920">

After:
<img width="1407" alt="Screenshot 2024-04-26 at 10 31 58 AM" src="https://github.com/ManageIQ/manageiq-providers-embedded_terraform/assets/32444791/96f4f9fa-5e38-4a02-a72c-b947727a5646">
<img width="1411" alt="Screenshot 2024-04-26 at 10 32 08 AM" src="https://github.com/ManageIQ/manageiq-providers-embedded_terraform/assets/32444791/5cbd731e-5bf6-4789-83b9-2d2420c0c1b4">

