### PR TITLE
Rename CloudCredential with TemplateCredential

### DIFF
--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/amazon_credential.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/amazon_credential.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::AmazonCredential < ManageIQ::Providers::EmbeddedTerraform::AutomationManager::CloudCredential
+class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::AmazonCredential < ManageIQ::Providers::EmbeddedTerraform::AutomationManager::TemplateCredential
   COMMON_ATTRIBUTES = [
     {
       :component  => 'text-field',

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/azure_credential.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/azure_credential.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::AzureCredential < ManageIQ::Providers::EmbeddedTerraform::AutomationManager::CloudCredential
+class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::AzureCredential < ManageIQ::Providers::EmbeddedTerraform::AutomationManager::TemplateCredential
   COMMON_ATTRIBUTES = [].freeze
 
   EXTRA_ATTRIBUTES = [

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/cloud_credential.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/cloud_credential.rb
@@ -1,2 +1,0 @@
-class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::CloudCredential < ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Credential
-end

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/google_credential.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/google_credential.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::GoogleCredential < ManageIQ::Providers::EmbeddedTerraform::AutomationManager::CloudCredential
+class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::GoogleCredential < ManageIQ::Providers::EmbeddedTerraform::AutomationManager::TemplateCredential
   COMMON_ATTRIBUTES = [
     {
       :component  => 'text-field',

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/ibm_cloud_credential.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/ibm_cloud_credential.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::IbmCloudCredential < ManageIQ::Providers::EmbeddedTerraform::AutomationManager::CloudCredential
+class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::IbmCloudCredential < ManageIQ::Providers::EmbeddedTerraform::AutomationManager::TemplateCredential
   COMMON_ATTRIBUTES = [
     {
       :component  => 'password-field',

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/openstack_credential.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/openstack_credential.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::OpenstackCredential < ManageIQ::Providers::EmbeddedTerraform::AutomationManager::CloudCredential
+class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::OpenstackCredential < ManageIQ::Providers::EmbeddedTerraform::AutomationManager::TemplateCredential
   COMMON_ATTRIBUTES = [
     {
       :component  => 'text-field',

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/template_credential.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/template_credential.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::TemplateCredential < ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Credential
+end

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/vsphere_credential.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/vsphere_credential.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::VsphereCredential < ManageIQ::Providers::EmbeddedTerraform::AutomationManager::CloudCredential
+class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::VsphereCredential < ManageIQ::Providers::EmbeddedTerraform::AutomationManager::TemplateCredential
   COMMON_ATTRIBUTES = [
     {
       :component  => 'text-field',


### PR DESCRIPTION
to give a meaningful common name, as vsphere may not be called cloud, it is a infra manager

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
