### PR TITLE
Split ibm cloud credentials from ibm classic infra credentials

### DIFF
--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/ibm_classic_infrastructure_credential.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/ibm_classic_infrastructure_credential.rb
@@ -28,11 +28,11 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::IbmClassicInfra
 
   API_OPTIONS = {
     :type       => 'cloud',
-    :label      => N_('IBM Classic Infrastructure'),
+    :label      => N_('IBM Cloud Classic Infrastructure'),
     :attributes => API_ATTRIBUTES
   }.freeze
 
   def self.display_name(number = 1)
-    n_('Credential (IBM Classic Infrastructure)', 'Credentials (IBM Classic Infrastructure)', number)
+    n_('Credential (IBM Cloud Classic Infrastructure)', 'Credentials (IBM Cloud Classic Infrastructure)', number)
   end
 end

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/ibm_classic_infrastructure_credential.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/ibm_classic_infrastructure_credential.rb
@@ -1,0 +1,38 @@
+class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::IbmClassicInfrastructureCredential < ManageIQ::Providers::EmbeddedTerraform::AutomationManager::TemplateCredential
+  COMMON_ATTRIBUTES = [].freeze
+
+  EXTRA_ATTRIBUTES = [
+    {
+      :component  => 'text-field',
+      :label      => N_('IBM Cloud Classic Infrastructure User Name'),
+      :helperText => N_('The User Name for IBM Cloud Classic Infrastructure.'),
+      :name       => 'userid',
+      :id         => 'userid',
+      :maxLength  => 100,
+      :isRequired => true,
+      :validate   => [{:type => 'required'}],
+    },
+    {
+      :component  => 'password-field',
+      :label      => N_('IBM Cloud Classic Infrastructure API Key'),
+      :helperText => N_('The API key for IBM Cloud Classic Infrastructure.'),
+      :name       => 'password',
+      :id         => 'password',
+      :type       => 'password',
+      :isRequired => true,
+      :validate   => [{:type => 'required'}],
+    },
+  ].freeze
+
+  API_ATTRIBUTES = (COMMON_ATTRIBUTES + EXTRA_ATTRIBUTES).freeze
+
+  API_OPTIONS = {
+    :type       => 'cloud',
+    :label      => N_('IBM Classic Infrastructure'),
+    :attributes => API_ATTRIBUTES
+  }.freeze
+
+  def self.display_name(number = 1)
+    n_('Credential (IBM Classic Infrastructure)', 'Credentials (IBM Classic Infrastructure)', number)
+  end
+end

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/ibm_cloud_credential.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/ibm_cloud_credential.rb
@@ -1,33 +1,16 @@
 class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::IbmCloudCredential < ManageIQ::Providers::EmbeddedTerraform::AutomationManager::TemplateCredential
-  COMMON_ATTRIBUTES = [
+  COMMON_ATTRIBUTES = [].freeze
+
+  EXTRA_ATTRIBUTES = [
     {
       :component  => 'password-field',
       :label      => N_('IBM Cloud API Key'),
-      :helperText => N_('The API key for IBM Cloud. A value for this field is required if classic user name and classic API key are not provided. A valid connection must have value for IBM Cloud API Key or, IBM Cloud Classic Infrastructure User Name and IBM Cloud Classic Infrastructure API Key.'),
+      :helperText => N_('The API key for IBM Cloud.'),
       :name       => 'auth_key',
       :id         => 'auth_key',
       :type       => 'password',
       :isRequired => true,
       :validate   => [{:type => 'required'}],
-    },
-  ].freeze
-
-  EXTRA_ATTRIBUTES = [
-    {
-      :component  => 'text-field',
-      :label      => N_('IBM Cloud Classic Infrastructure User Name'),
-      :helperText => N_('The User Name for IBM Cloud Classic Infrastructure. A value for this field is required when using classic IBM Cloud resources. A valid connection must have value for IBM Cloud API Key or, IBM Cloud Classic Infrastructure User Name and IBM Cloud Classic Infrastructure API Key.'),
-      :name       => 'classic_user',
-      :id         => 'classic_user',
-      :maxLength  => 100,
-    },
-    {
-      :component  => 'password-field',
-      :label      => N_('IBM Cloud Classic Infrastructure API Key'),
-      :helperText => N_('The API key for IBM Cloud Classic Infrastructure A value for this field is required when using classic IBM Cloud resources. A valid connection must have value for IBM Cloud API Key or, IBM Cloud Classic Infrastructure User Name and IBM Cloud Classic Infrastructure API Key.'),
-      :name       => 'classic_key',
-      :id         => 'classic_key',
-      :type       => 'password',
     },
   ].freeze
 
@@ -41,18 +24,5 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::IbmCloudCredent
 
   def self.display_name(number = 1)
     n_('Credential (IBM Cloud)', 'Credentials (IBM Cloud)', number)
-  end
-
-  def self.params_to_attributes(params)
-    attrs = super.dup
-
-    attrs[:auth_key] = attrs.delete(:auth_key) if attrs.key?(:auth_key)
-
-    if %i[classic_user classic_key].any? { |opt| attrs.key?(opt) }
-      attrs[:userid]   = attrs.delete(:classic_user) if attrs.key?(:classic_user)
-      attrs[:password] = attrs.delete(:classic_key)  if attrs.key?(:classic_key)
-    end
-
-    attrs
   end
 end

--- a/lib/terraform/runner/ibm_classic_infrastructure_credential.rb
+++ b/lib/terraform/runner/ibm_classic_infrastructure_credential.rb
@@ -1,8 +1,8 @@
 module Terraform
   class Runner
-    class IbmCloudCredential < Credential
+    class IbmClassicInfrastructureCredential < Credential
       def self.auth_type
-        "ManageIQ::Providers::EmbeddedTerraform::AutomationManager::IbmCloudCredential"
+        "ManageIQ::Providers::EmbeddedTerraform::AutomationManager::IbmClassicInfrastructureCredential"
       end
 
       # Modeled off of IBM Cloud provider for terraform:
@@ -14,7 +14,8 @@ module Terraform
       def connection_parameters
         conn_params = []
 
-        ApiParams.add_param_if_present(conn_params, auth.auth_key, 'IC_API_KEY')
+        ApiParams.add_param_if_present(conn_params, auth.userid,   'IAAS_CLASSIC_USERNAME')
+        ApiParams.add_param_if_present(conn_params, auth.password, 'IAAS_CLASSIC_API_KEY')
 
         conn_params
       end

--- a/spec/factories/authentication.rb
+++ b/spec/factories/authentication.rb
@@ -27,7 +27,11 @@ FactoryBot.define do
           :parent => :embedded_terraform_credential,
           :class  => "ManageIQ::Providers::EmbeddedTerraform::AutomationManager::OpenstackCredential"
 
-  factory :embedded_terraform_ibmcloud_credential,
+  factory :embedded_terraform_ibm_cloud_credential,
           :parent => :embedded_terraform_credential,
           :class  => "ManageIQ::Providers::EmbeddedTerraform::AutomationManager::IbmCloudCredential"
+
+  factory :embedded_terraform_ibm_classic_infrastructure_credential,
+          :parent => :embedded_terraform_credential,
+          :class  => "ManageIQ::Providers::EmbeddedTerraform::AutomationManager::IbmClassicInfrastructureCredential"
 end

--- a/spec/lib/terraform/runner/ibm_classic_infrastructure_credential_spec.rb
+++ b/spec/lib/terraform/runner/ibm_classic_infrastructure_credential_spec.rb
@@ -1,0 +1,42 @@
+require 'terraform/runner'
+
+RSpec.describe(Terraform::Runner::IbmClassicInfrastructureCredential) do
+  it ".auth_type is the correct Authentication sub-class" do
+    expect(described_class.auth_type).to(eq("ManageIQ::Providers::EmbeddedTerraform::AutomationManager::IbmClassicInfrastructureCredential"))
+  end
+
+  context "with a credential object" do
+    let(:auth) { FactoryBot.create(:embedded_terraform_ibm_classic_infrastructure_credential, auth_attributes) }
+    let(:auth_attributes) do
+      {
+        :userid   => 'iaas-classic-username',
+        :password => 'iaas-classic-api-key',
+      }
+    end
+
+    let(:cred) { described_class.new(auth.id) }
+
+    # Modeled off of IBM Cloud provider for terraform:
+    #
+    #   https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs#environment-variables
+    #
+    describe "#connection_parameters" do
+      it "adds IAAS_CLASSIC_USERNAME, IAAS_CLASSIC_USERNAME if present" do
+        auth.update!(:auth_key => '')
+        expected = [
+          {
+            'name'    => 'IAAS_CLASSIC_USERNAME',
+            'value'   => 'iaas-classic-username',
+            'secured' => 'false',
+          },
+          {
+            'name'    => 'IAAS_CLASSIC_API_KEY',
+            'value'   => 'iaas-classic-api-key',
+            'secured' => 'false',
+          },
+        ]
+        expect(cred.connection_parameters).to(eq(expected))
+      end
+    end
+  end
+end

--- a/spec/lib/terraform/runner/ibm_cloud_credential_spec.rb
+++ b/spec/lib/terraform/runner/ibm_cloud_credential_spec.rb
@@ -6,12 +6,10 @@ RSpec.describe(Terraform::Runner::IbmCloudCredential) do
   end
 
   context "with a credential object" do
-    let(:auth) { FactoryBot.create(:embedded_terraform_ibmcloud_credential, auth_attributes) }
+    let(:auth) { FactoryBot.create(:embedded_terraform_ibm_cloud_credential, auth_attributes) }
     let(:auth_attributes) do
       {
         :auth_key => 'ibmcloud-api-key',
-        :userid   => 'iaas-classic-username',
-        :password => 'iaas-classic-api-key',
       }
     end
 
@@ -33,29 +31,6 @@ RSpec.describe(Terraform::Runner::IbmCloudCredential) do
         ]
         expect(cred.connection_parameters).to(eq(expected))
       end
-
-      it "adds IAAS_CLASSIC_USERNAME, IAAS_CLASSIC_USERNAME if present" do
-        auth.update!(:auth_key => '')
-        expected = [
-          {
-            'name'    => 'IAAS_CLASSIC_USERNAME',
-            'value'   => 'iaas-classic-username',
-            'secured' => 'false',
-          },
-          {
-            'name'    => 'IAAS_CLASSIC_API_KEY',
-            'value'   => 'iaas-classic-api-key',
-            'secured' => 'false',
-          },
-        ]
-        expect(cred.connection_parameters).to(eq(expected))
-      end
     end
-
-    # describe "#env_vars" do
-    #   it "returns an empty hash" do
-    #     expect(cred.env_vars).to(eq({}))
-    #   end
-    # end
   end
 end

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/credential_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/credential_spec.rb
@@ -584,28 +584,28 @@ RSpec.describe(ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Creden
 
       let(:params) do
         {
-          :name     => "IBM Classic Infrastructure Credential",
+          :name     => "IBM Cloud Classic Infrastructure Credential",
           :userid   => "user1",
           :password => "secret2",
         }
       end
       let(:queue_create_params) do
         {
-          :name     => "IBM Classic Infrastructure Credential",
+          :name     => "IBM Cloud Classic Infrastructure Credential",
           :userid   => "user1",
           :password => ManageIQ::Password.encrypt("secret2"),
         }
       end
       let(:params_to_attributes) do
         {
-          :name     => "IBM Classic Infrastructure Credential",
+          :name     => "IBM Cloud Classic Infrastructure Credential",
           :userid   => "user1",
           :password => "secret2",
         }
       end
       let(:expected_values) do
         {
-          :name               => "IBM Classic Infrastructure Credential",
+          :name               => "IBM Cloud Classic Infrastructure Credential",
           :userid             => "user1",
           :password_encrypted => ManageIQ::Password.encrypt("secret2"),
         }

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/credential_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/credential_spec.rb
@@ -539,47 +539,88 @@ RSpec.describe(ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Creden
 
       let(:params) do
         {
-          :name         => "IBM Cloud Credential",
-          :auth_key     => "secret1",
-          :classic_user => "user1",
-          :classic_key  => "secret2",
+          :name     => "IBM Cloud Credential",
+          :auth_key => "secret1",
         }
       end
       let(:queue_create_params) do
         {
-          :name         => "IBM Cloud Credential",
-          :auth_key     => ManageIQ::Password.encrypt("secret1"),
-          :classic_user => "user1",
-          :classic_key  => ManageIQ::Password.encrypt("secret2"),
+          :name     => "IBM Cloud Credential",
+          :auth_key => ManageIQ::Password.encrypt("secret1"),
         }
       end
       let(:params_to_attributes) do
         {
           :name     => "IBM Cloud Credential",
           :auth_key => "secret1",
+        }
+      end
+      let(:expected_values) do
+        {
+          :name               => "IBM Cloud Credential",
+          :auth_key_encrypted => ManageIQ::Password.encrypt("secret1"),
+          :auth_key           => "secret1"
+        }
+      end
+      let(:params_to_attrs) { [] }
+      let(:update_params) do
+        {
+          :name     => "Updated Credential",
+          :auth_key => "supersecret"
+        }
+      end
+      let(:update_queue_params) do
+        {
+          :name     => "Updated Credential",
+          :auth_key => ManageIQ::Password.encrypt("supersecret")
+        }
+      end
+    end
+  end
+
+  context "IbmClassicInfrastructureCredential" do
+    it_behaves_like 'an embedded_terraform credential' do
+      let(:credential_class) { embedded_terraform::IbmClassicInfrastructureCredential }
+
+      let(:params) do
+        {
+          :name     => "IBM Classic Infrastructure Credential",
+          :userid   => "user1",
+          :password => "secret2",
+        }
+      end
+      let(:queue_create_params) do
+        {
+          :name     => "IBM Classic Infrastructure Credential",
+          :userid   => "user1",
+          :password => ManageIQ::Password.encrypt("secret2"),
+        }
+      end
+      let(:params_to_attributes) do
+        {
+          :name     => "IBM Classic Infrastructure Credential",
           :userid   => "user1",
           :password => "secret2",
         }
       end
       let(:expected_values) do
         {
-          :name               => "IBM Cloud Credential",
-          :auth_key_encrypted => ManageIQ::Password.try_encrypt("secret1"),
+          :name               => "IBM Classic Infrastructure Credential",
           :userid             => "user1",
-          :password_encrypted => ManageIQ::Password.try_encrypt("secret2"),
+          :password_encrypted => ManageIQ::Password.encrypt("secret2"),
         }
       end
-      let(:params_to_attrs) { [:auth_key, :userid] }
+      let(:params_to_attrs) { [] }
       let(:update_params) do
         {
-          :name        => "Updated Credential",
-          :classic_key => "supersecret"
+          :name     => "Updated Credential",
+          :password => "supersecret"
         }
       end
       let(:update_queue_params) do
         {
-          :name        => "Updated Credential",
-          :classic_key => ManageIQ::Password.encrypt("supersecret")
+          :name     => "Updated Credential",
+          :password => ManageIQ::Password.encrypt("supersecret")
         }
       end
     end


### PR DESCRIPTION
I think this simplifies the required field logic.  We'll need to make sure connecting from within the runner works but this is the start of enabling that work.

![image](https://github.com/ManageIQ/manageiq-providers-embedded_terraform/assets/19339/cf847c8c-dafd-45ab-bd26-2e36b2160aa4)

![image](https://github.com/ManageIQ/manageiq-providers-embedded_terraform/assets/19339/9b0f1434-348c-4751-bf32-04d3e837b15b)

![image](https://github.com/ManageIQ/manageiq-providers-embedded_terraform/assets/19339/ca4cc985-6a5e-43d3-b9e2-61a988b7e209)

![image](https://github.com/ManageIQ/manageiq-providers-embedded_terraform/assets/19339/cdcc28cf-3330-4e4e-b80e-20b0eb2a2af3)

