### PR TITLE
Fix missing create_container_objects method in OpentofuRunner

### DIFF
--- a/app/models/opentofu_worker.rb
+++ b/app/models/opentofu_worker.rb
@@ -1,4 +1,6 @@
 class OpentofuWorker < MiqWorker
+  include MiqWorker::ServiceWorker
+
   self.required_roles        = ["embedded_terraform"]
   self.rails_worker          = false
   self.maximum_workers_count = 1


### PR DESCRIPTION
Fixes
```
[NameError]: undefined local variable or method `create_container_objects' for #<OpentofuWorker id: nil, guid: \"fbf252d1-731d-49e8-8aba-54787fceccdf\", status: \"creating\", started_on: nil, stopped_on: nil, last_heartbeat: \"2024-05-14 12:51:33.918002950 +0000\", pid: nil, queue_name: nil, type: \"OpentofuWorker\", percent_memory: nil, percent_cpu: nil, cpu_time: nil, os_priority: nil, memory_usage: nil, memory_size: nil, uri: nil, miq_server_id: 1, sql_spid: nil, proportional_set_size: nil, unique_set_size: nil, system_uid: nil>\nDid you mean?  create_podman_secret  Method:[block (2 levels) in <class:LogProxy>]
/var/www/miq/vmdb/app/models/miq_worker.rb:354:in `start_runner_via_container'
/var/www/miq/vmdb/app/models/miq_worker.rb:347:in `start_runner'
/var/www/miq/vmdb/app/models/miq_worker.rb:393:in `start'
/var/www/miq/vmdb/app/models/miq_worker.rb:313:in `start_worker'
/var/www/miq/vmdb/app/models/miq_worker.rb:168:in `block in sync_workers'
/var/www/miq/vmdb/app/models/miq_worker.rb:168:in `times'
/var/www/miq/vmdb/app/models/miq_worker.rb:168:in `sync_workers'
/var/www/miq/vmdb/app/models/miq_server/worker_management/monitor.rb:40:in `block in sync_workers'
/var/www/miq/vmdb/app/models/miq_server/worker_management/monitor.rb:39:in `each'
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
