### PR TITLE
Fix OpentofuWorker worker_deployment_name

### DIFF
--- a/app/models/opentofu_worker.rb
+++ b/app/models/opentofu_worker.rb
@@ -13,12 +13,12 @@ class OpentofuWorker < MiqWorker
     "#{service_base_name}.service"
   end
 
-  def self.worker_deployment_name
-    "opentofu-runner"
-  end
-
   def self.kill_priority
     MiqWorkerType::KILL_PRIORITY_GENERIC_WORKERS
+  end
+
+  def worker_deployment_name
+    @worker_deployment_name ||= "#{deployment_prefix}opentofu-runner"
   end
 
   private

--- a/spec/factories/miq_worker.rb
+++ b/spec/factories/miq_worker.rb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+  factory :opentofu_worker, :class => "OpentofuWorker", :parent => :miq_worker
+end

--- a/spec/models/opentofu_worker_spec.rb
+++ b/spec/models/opentofu_worker_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe OpentofuWorker do
+  let(:miq_server) { EvmSpecHelper.local_miq_server }
+  let(:worker)     { FactoryBot.create(:opentofu_worker, :miq_server => miq_server) }
+
+  it ".service_base_name" do
+    expect(described_class.service_base_name).to eq("opentofu-runner")
+  end
+
+  it ".service_file" do
+    expect(described_class.service_file).to eq("opentofu-runner.service")
+  end
+
+  it "#unit_name" do
+    expect(worker.unit_name).to eq("opentofu-runner.service")
+  end
+
+  it "#container_port" do
+    expect(worker.container_port).to eq(3000)
+  end
+
+  it "#worker_deployment_name" do
+    expect(worker.worker_deployment_name).to eq("#{miq_server.compressed_id}-opentofu-runner")
+  end
+end


### PR DESCRIPTION
The systemd service name is "opentofu-runner" so it would make sense to have the podified deployment match.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
