### PR TITLE
Override default containerport 3000 to opentofu runner port 6000

### DIFF
--- a/app/models/opentofu_worker.rb
+++ b/app/models/opentofu_worker.rb
@@ -5,8 +5,6 @@ class OpentofuWorker < MiqWorker
   self.rails_worker          = false
   self.maximum_workers_count = 1
 
-  STARTING_PORT = 6000
-
   def self.service_base_name
     "opentofu-runner"
   end
@@ -24,7 +22,7 @@ class OpentofuWorker < MiqWorker
   end
 
   def container_port
-    6001
+    6000
   end
 
   private

--- a/app/models/opentofu_worker.rb
+++ b/app/models/opentofu_worker.rb
@@ -5,6 +5,8 @@ class OpentofuWorker < MiqWorker
   self.rails_worker          = false
   self.maximum_workers_count = 1
 
+  STARTING_PORT = 6000
+
   def self.service_base_name
     "opentofu-runner"
   end
@@ -19,6 +21,10 @@ class OpentofuWorker < MiqWorker
 
   def worker_deployment_name
     @worker_deployment_name ||= "#{deployment_prefix}opentofu-runner"
+  end
+
+  def container_port
+    6001
   end
 
   private

--- a/app/models/opentofu_worker.rb
+++ b/app/models/opentofu_worker.rb
@@ -5,7 +5,7 @@ class OpentofuWorker < MiqWorker
   self.rails_worker          = false
   self.maximum_workers_count = 1
 
-  HEALTH_PORT  = 6000
+  HEALTH_PORT = 6000
 
   def self.service_base_name
     "opentofu-runner"
@@ -28,7 +28,7 @@ class OpentofuWorker < MiqWorker
   end
 
   def add_liveness_probe(container_definition)
-    container_definition[:livenessProbe] = container_definition[:livenessProbe].except(:exec).merge(:httpGet => {:path => "/api/v1/ready", :port => HEALTH_PORT, :scheme => "HTTPS" })
+    container_definition[:livenessProbe] = container_definition[:livenessProbe].except(:exec).merge(:httpGet => {:path => "/api/v1/ready", :port => HEALTH_PORT, :scheme => "HTTPS"})
   end
 
   def add_readiness_probe(container_definition)

--- a/app/models/opentofu_worker.rb
+++ b/app/models/opentofu_worker.rb
@@ -5,6 +5,8 @@ class OpentofuWorker < MiqWorker
   self.rails_worker          = false
   self.maximum_workers_count = 1
 
+  HEALTH_PORT  = 6000
+
   def self.service_base_name
     "opentofu-runner"
   end
@@ -23,6 +25,18 @@ class OpentofuWorker < MiqWorker
 
   def container_port
     6000
+  end
+
+  def add_liveness_probe(container_definition)
+    container_definition[:livenessProbe] = container_definition[:livenessProbe].except(:exec).merge(:httpGet => {:path => "/api/v1/ready", :port => HEALTH_PORT, :scheme => "HTTPS" })
+  end
+
+  def add_readiness_probe(container_definition)
+    container_definition[:readinessProbe] = {
+      :httpGet             => {:path => "/api/v1/ready", :port => HEALTH_PORT, :scheme => "HTTPS"},
+      :initialDelaySeconds => 60,
+      :timeoutSeconds      => 3
+    }
   end
 
   private

--- a/spec/models/opentofu_worker_spec.rb
+++ b/spec/models/opentofu_worker_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe OpentofuWorker do
   end
 
   it "#container_port" do
-    expect(worker.container_port).to eq(6001)
+    expect(worker.container_port).to eq(6000)
   end
 
   it "#worker_deployment_name" do

--- a/spec/models/opentofu_worker_spec.rb
+++ b/spec/models/opentofu_worker_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe OpentofuWorker do
   end
 
   it "#container_port" do
-    expect(worker.container_port).to eq(3000)
+    expect(worker.container_port).to eq(6001)
   end
 
   it "#worker_deployment_name" do


### PR DESCRIPTION
Container port defined in worker core deployment teamplate is 3000.
But we want opentofu-runner to work on 6000 port. Overriding the same in embedded plugin