### PR TITLE
Fix Provision options for EmbeddedTerraform Stack

### DIFF
--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb
@@ -36,7 +36,7 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
     private
 
     def collect_authentications(manager, options)
-      credential_ids = options[:credential] || []
+      credential_ids = options[:credentials] || []
 
       manager.credentials.where(:id => credential_ids)
     end

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/template.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/template.rb
@@ -3,7 +3,7 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Template < Mana
 
   def run(vars = {}, _userid = nil)
     env_vars    = vars.delete(:env)        || {}
-    credentials = vars.delete(:credential) || []
+    credentials = vars.delete(:credentials)
 
     self.class.module_parent::Job.create_job(self, env_vars, vars, credentials).tap(&:signal_start)
   end

--- a/app/models/service_terraform_template.rb
+++ b/app/models/service_terraform_template.rb
@@ -1,8 +1,25 @@
 class ServiceTerraformTemplate < ServiceGeneric
   delegate :terraform_template, :to => :service_template, :allow_nil => true
 
+  CONFIG_OPTIONS_WHITELIST = %i[
+    credential_id
+    execution_ttl
+    extra_vars
+    verbosity
+  ].freeze
+
   def my_zone
     miq_request&.my_zone
+  end
+
+  # A chance for taking options from automate script to override options from a service dialog
+  def preprocess(action, add_options = {})
+    if add_options.present?
+      _log.info("Override with new options:")
+      $log.log_hashes(add_options)
+    end
+
+    save_job_options(action, add_options)
   end
 
   def execute(action)
@@ -37,11 +54,45 @@ class ServiceTerraformTemplate < ServiceGeneric
   def launch_terraform_template(action)
     terraform_template = terraform_template(action)
 
-    stack = ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack.create_stack(terraform_template, options)
+    stack = ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack.create_stack(terraform_template, get_job_options(action))
     add_resource!(stack, :name => action)
   end
 
   def stack(action)
     service_resources.find_by(:name => action, :resource_type => 'OrchestrationStack').try(:resource)
+  end
+
+  private
+
+  def get_job_options(action)
+    options[job_option_key(action)].deep_dup
+  end
+
+  def config_options(action)
+    options.fetch_path(:config_info, action.downcase.to_sym).slice(*CONFIG_OPTIONS_WHITELIST).with_indifferent_access
+  end
+
+  def save_job_options(action, overrides)
+    job_options = config_options(action)
+    job_options[:extra_vars].try(:transform_values!) do |val|
+      val.kind_of?(String) ? val : val[:default] # TODO: support Hash only
+    end
+    # TODO: job_options.deep_merge!(parse_dialog_options) unless action == ResourceAction::RETIREMENT
+    job_options.deep_merge!(overrides)
+    translate_credentials!(job_options)
+
+    options[job_option_key(action)] = job_options
+    save!
+  end
+
+  def job_option_key(action)
+    "#{action.downcase}_job_options".to_sym
+  end
+
+  def translate_credentials!(options)
+    options[:credentials] = []
+
+    credential_id = options.delete(:credential_id)
+    options[:credentials] << Authentication.find(credential_id).native_ref if credential_id.present?
   end
 end


### PR DESCRIPTION
The options column for a ServiceTerraformTemplate includes information that isn't necessary for a provision request and the options sent to the Stack.create_stack should be tailored to only include what is necessary.

Also this fixes the credential IDs being passed down since those values were in the options.config_info.provision hash.

Example `:options` from a `ServiceTerraformTemplate`
```
>> pp ServiceTerraformTemplate.first.options                             
=>                                                                   
{:config_info=>                                                      
  {:provision=>{:repository_id=>"1", :execution_ttl=>60, :log_output=>"on_error", :verbosity=>"0", :extra_vars=>{:FOO=>{:default=>"Bar"}}, :dialog_id=>"1", :configuration_script_payload_id=>"18", :credential_id=>"2", :fqname=>"/Service/Generic/StateMachines/GenericLifecycle/provision"},
   :retirement=>{:fqname=>"/Service/Generic/StateMachines/GenericLifecycle/Retire_Basic_Resource"}},
 :dialog=>{"dialog_text_box_1"=>""},                                 
 :provision_automate_timeout=>100}
```

Example `provision_job_options` which is what is sent to the `Stack.create_stack`
```ruby
{:provision_job_options=>{"execution_ttl"=>60, "extra_vars"=>{"FOO"=>"Bar"}, "verbosity"=>"0", "credential"=>2}}
```

Example options sent to Terraform::Runner.run`

```ruby
=> 25:     response = Terraform::Runner.run(
   26:       options[:input_vars],
   27:       template_path,
   28:       :credentials => options[:credentials],
   29:       :env_vars    => options[:env_vars]
(byebug) pp options
{:template_id=>18, :env_vars=>{}, :input_vars=>{"execution_ttl"=>60, "extra_vars"=>{"FOO"=>"Bar"}, "verbosity"=>"0"}, :credentials=>[2], :poll_interval=>1 minute, :git_checkout_tempdir=>"/tmp/embedded-terraform-runner-git20240523-157937-zvo18d"}
{:template_id=>18, :env_vars=>{}, :input_vars=>{"execution_ttl"=>60, "extra_vars"=>{"FOO"=>"Bar"}, "verbosity"=>"0"}, :credentials=>[2], :poll_interval=>1 minute, :git_checkout_tempdir=>"/tmp/embedded-terraform-runner-git20240523-157937-zvo18d"}
(byebug) options[:input_vars]
{"execution_ttl"=>60, "extra_vars"=>{"FOO"=>"Bar"}, "verbosity"=>"0"}
(byebug) template_path
"/tmp/embedded-terraform-runner-git20240523-157937-zvo18d/Google/terraform/hcl/singleVM"
(byebug) options[:credentials]
[2]
(byebug) options[:env_vars]
{}
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
