### PR TITLE
Fix Terraform::Runner credentials

### DIFF
--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
@@ -20,11 +20,12 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
 
   def execute
     template_path = File.join(options[:git_checkout_tempdir], template_relative_path)
+    credentials   = Authentication.where(:id => options[:credentials])
 
     response = Terraform::Runner.run(
       options[:input_vars],
       template_path,
-      :credentials => options[:credentials],
+      :credentials => credentials,
       :env_vars    => options[:env_vars]
     )
 

--- a/lib/terraform/runner.rb
+++ b/lib/terraform/runner.rb
@@ -21,7 +21,7 @@ module Terraform
       #        terraform-runner run
       # @param template_path [String] Path to the template we will want to run
       # @param tags [Hash] Hash with key/values pairs that will be passed as tags to the terraform-runner run
-      # @param credentials [Array] List of Authentication object ids to provide to the terraform run
+      # @param credentials [Array] List of Authentication objects to provide to the terraform run
       # @param env_vars [Hash] Hash with key/value pairs that will be passed as environment variables to the
       #        terraform-runner run
       # @return [Terraform::Runner::ResponseAsync] Response object of terraform-runner create action


### PR DESCRIPTION
The Terraform::Runner expects Authentication objects so update the method description and pass ActiveRecord objects instead of IDs

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
