### PR TITLE
Fix opentofu-runner postgresql connection refused

### DIFF
--- a/systemd/opentofu-runner.service
+++ b/systemd/opentofu-runner.service
@@ -6,7 +6,7 @@ WantedBy=opentofu-runner.target
 User=manageiq
 Group=manageiq
 ExecStartPre=/bin/rm -f /tmp/%n.cid
-ExecStart=/usr/bin/podman run --conmon-pidfile %T/%N.pid --cidfile %T/%N.cid --cgroup-manager=cgroupfs --cgroups=no-conmon --log-driver=journald --replace --name=opentofu-runner --secret=opentofu-runner-secret --root=/var/www/miq/vmdb/data/containers/storage --env=DATABASE_HOSTNAME=${DATABASE_HOSTNAME} --env=DATABASE_NAME=${DATABASE_NAME} --env=DATABASE_USERNAME=${DATABASE_USERNAME} --env=MEMCACHE_SERVERS=${MEMCACHE_SERVERS} --volume=/var/lib/manageiq/opentofu-runner/certs:/opt/app-root/src/config/cert:z --expose=6000 $OPENTOFU_RUNNER_IMAGE
+ExecStart=/usr/bin/podman run --conmon-pidfile %T/%N.pid --cidfile %T/%N.cid --cgroup-manager=cgroupfs --cgroups=no-conmon --log-driver=journald --replace --name=opentofu-runner --secret=opentofu-runner-secret --root=/var/www/miq/vmdb/data/containers/storage --env=DATABASE_HOSTNAME=${DATABASE_HOSTNAME} --env=DATABASE_NAME=${DATABASE_NAME} --env=DATABASE_USERNAME=${DATABASE_USERNAME} --env=MEMCACHE_SERVERS=${MEMCACHE_SERVERS} --volume=/var/lib/manageiq/opentofu-runner/certs:/opt/app-root/src/config/cert:z --expose=6000 --net=host $OPENTOFU_RUNNER_IMAGE
 ExecStop=/usr/bin/podman stop --ignore -t 30 --cidfile %T/%N.cid --cgroup-manager=cgroupfs --root=/var/www/miq/vmdb/data/containers/storage
 ExecStopPost=/usr/bin/podman rm --ignore --cidfile %T/%N.cid --cgroup-manager=cgroupfs --root=/var/www/miq/vmdb/data/containers/storage
 ExecStopPost=/usr/bin/rm -f %T/%N.pid %T/%N.cid


### PR DESCRIPTION
NOTE `--net=host` is just a placeholder, but even using eth0's addr or host.containers.local I'm not able to connect to postgres from within the pod

```
opentofu-runner[17378]: Error: getaddrinfo ENOTFOUND host.containers.internal
opentofu-runner[17378]:     at GetAddrInfoReqWrap.onlookup [as oncomplete] (node:dns:107:26)
opentofu-runner[17378]: Emitted 'error' event on DataSource instance at:
opentofu-runner[17378]:     at DataSource.postInit (/opt/app-root/src/node_modules/loopback/node_modules/loopback-datasource-juggler/lib/datasource.js:489:16)
opentofu-runner[17378]:     at PendingItem.callback (/opt/app-root/src/node_modules/loopback-connector-postgresql/lib/postgresql.js:130:17)
opentofu-runner[17378]:     at Client._connectionCallback (/opt/app-root/src/node_modules/pg-pool/index.js:254:23)
opentofu-runner[17378]:     at Client._handleErrorWhileConnecting (/opt/app-root/src/node_modules/pg/lib/client.js:327:19)
opentofu-runner[17378]:     at Client._handleErrorEvent (/opt/app-root/src/node_modules/pg/lib/client.js:337:19)
opentofu-runner[17378]:     at Connection.emit (node:events:517:28)
opentofu-runner[17378]:     at Socket.reportStreamError (/opt/app-root/src/node_modules/pg/lib/connection.js:58:12)
opentofu-runner[17378]:     at Socket.emit (node:events:517:28)
opentofu-runner[17378]:     at emitErrorNT (node:internal/streams/destroy:151:8)
opentofu-runner[17378]:     at emitErrorCloseNT (node:internal/streams/destroy:116:3)
opentofu-runner[17378]:     at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
opentofu-runner[17378]:   errno: -3008,
opentofu-runner[17378]:   code: 'ENOTFOUND',
opentofu-runner[17378]:   syscall: 'getaddrinfo',
opentofu-runner[17378]:   hostname: 'host.containers.internal'
opentofu-runner[17378]: }
opentofu-runner[17378]:
opentofu-runner[17378]: Node.js v18.20.2
```

From within the running pod:
```
bash-5.1$ cat /etc/hosts
192.168.122.233	manageiq-devel.localdomain manageiq-devel
127.0.0.1	localhost localhost.localdomain localhost4 localhost4.localdomain4
::1	localhost localhost.localdomain localhost6 localhost6.localdomain6
192.168.122.233	host.containers.internal host.docker.internal
bash-5.1$ id
uid=10001(node) gid=10001(node) groups=10001(node)
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
