### PR TITLE
Implement ServiceTerraformTemplate#refresh

### DIFF
--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb
@@ -42,6 +42,15 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
     end
   end
 
+  def refresh
+    transaction do
+      self.status      = miq_task.state
+      self.start_time  = miq_task.started_on
+      self.finish_time = raw_status.completed? ? miq_task.updated_on : nil
+      save!
+    end
+  end
+
   def raw_status
     Status.new(miq_task, nil)
   end

--- a/app/models/service_terraform_template.rb
+++ b/app/models/service_terraform_template.rb
@@ -62,6 +62,14 @@ class ServiceTerraformTemplate < ServiceGeneric
     service_resources.find_by(:name => action, :resource_type => 'OrchestrationStack').try(:resource)
   end
 
+  def refresh(action)
+    stack(action).refresh
+  end
+
+  def check_refreshed(_action)
+    [true, nil]
+  end
+
   private
 
   def get_job_options(action)


### PR DESCRIPTION
```
INFO -- automation: Q-task_id([r5_service_template_provision_task_5]) <AEMethod refresh> Starting Refresh
ERROR -- automation: Q-task_id([r5_service_template_provision_task_5]) The following error occurred during instance method <refresh> for AR object <#<ServiceTerraformTemplate id: 5, name: "Terraform Test", description: "", guid: "1e2e1ef9-66a2-4cf4-bc5e-c60c564d58f0", type: "ServiceTerraformTemplate", service_templa>
ERROR -- automation: Q-task_id([r5_service_template_provision_task_5]) MiqAeServiceModelBase.ar_method raised: <NotImplementedError>: <refresh must be implemented in a subclass>
ERROR -- automation: Q-task_id([r5_service_template_provision_task_5]) /var/www/miq/vmdb/app/models/service_generic.rb:21:in `refresh'
```

Fixes https://github.com/ManageIQ/manageiq-providers-embedded_terraform/issues/37
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
