### PR TITLE
[WIP] Raise an error if terraform runner run fails

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -1,0 +1,3 @@
+Style/GlobalVars:
+  AllowedVariables:
+  - $embedded_terraform_log

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
@@ -22,7 +22,7 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
     template_path = File.join(options[:git_checkout_tempdir], template_relative_path)
     credentials   = Authentication.where(:id => options[:credentials])
 
-    response = Terraform::Runner.run(
+    response = Terraform::Runner.run!(
       options[:input_vars],
       template_path,
       :credentials => credentials,
@@ -33,6 +33,8 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
     save!
 
     queue_poll_runner
+  rescue Terraform::Runner::Error => err
+    signal_abort(err.message, "error")
   end
 
   def poll_runner

--- a/lib/terraform/runner.rb
+++ b/lib/terraform/runner.rb
@@ -56,7 +56,7 @@ module Terraform
       def run(input_vars, template_path, tags: nil, credentials: [], env_vars: {})
         run!(input_vars, template_path, :tags => tags, :credentials => credentials, :env_vars => env_vars)
       rescue Terraform::Runner::Error => err
-        _log.error("Failed to run template [#{template_path}]: #{err}")
+        $embedded_terraform_log.error("Failed to run template [#{template_path}]: #{err}")
         nil
       end
 
@@ -139,7 +139,7 @@ module Terraform
         env_vars: {},
         name: "stack-#{rand(36**8).to_s(36)}"
       )
-        _log.info("start stack_job for template: #{template_path}")
+        $embedded_terraform_log.info("start stack_job for template: #{template_path}")
         tenant_id = stack_tenant_id
         encoded_zip_file = encoded_zip_from_directory(template_path)
 
@@ -156,8 +156,8 @@ module Terraform
           "api/stack/create",
           *json_post_arguments(payload)
         )
-        _log.debug("==== http_response.body: \n #{http_response.body}")
-        _log.info("stack_job for template: #{template_path} running ...")
+        $embedded_terraform_log.debug("==== http_response.body: \n #{http_response.body}")
+        $embedded_terraform_log.info("stack_job for template: #{template_path} running ...")
         Terraform::Runner::Response.parsed_response(http_response)
       end
 
@@ -167,7 +167,7 @@ module Terraform
           "api/stack/retrieve",
           *json_post_arguments({:stack_id => stack_id})
         )
-        _log.info("==== Retrieve Stack Response: \n #{http_response.body}")
+        $embedded_terraform_log.info("==== Retrieve Stack Response: \n #{http_response.body}")
         Terraform::Runner::Response.parsed_response(http_response)
       end
 
@@ -177,7 +177,7 @@ module Terraform
           "api/stack/cancel",
           *json_post_arguments({:stack_id => stack_id})
         )
-        _log.info("==== Cancel Stack Response: \n #{http_response.body}")
+        $embedded_terraform_log.info("==== Cancel Stack Response: \n #{http_response.body}")
         Terraform::Runner::Response.parsed_response(http_response)
       end
 
@@ -187,11 +187,11 @@ module Terraform
         dir_path = dir_path[0...-1] if dir_path.end_with?('/')
 
         Tempfile.create(%w[opentofu-runner-payload .zip]) do |zip_file_path|
-          _log.debug("Create #{zip_file_path}")
+          $embedded_terraform_log.debug("Create #{zip_file_path}")
           Zip::File.open(zip_file_path, Zip::File::CREATE) do |zipfile|
             Dir.chdir(dir_path)
             Dir.glob("**/*").select { |fn| File.file?(fn) }.each do |file|
-              _log.debug("Adding #{file}")
+              $embedded_terraform_log.debug("Adding #{file}")
               zipfile.add(file.sub("#{dir_path}/", ''), file)
             end
           end

--- a/lib/terraform/runner.rb
+++ b/lib/terraform/runner.rb
@@ -25,7 +25,7 @@ module Terraform
       # @param env_vars [Hash] Hash with key/value pairs that will be passed as environment variables to the
       #        terraform-runner run
       # @return [Terraform::Runner::ResponseAsync] Response object of terraform-runner create action
-      def run_async(input_vars, template_path, tags: nil, credentials: [], env_vars: {})
+      def run(input_vars, template_path, tags: nil, credentials: [], env_vars: {})
         _log.debug("Run_aysnc template: #{template_path}")
         response = create_stack_job(
           template_path,
@@ -37,16 +37,12 @@ module Terraform
         Terraform::Runner::ResponseAsync.new(response.stack_id)
       end
 
-      # To simplify clients who may just call run, we alias it to call
-      # run_async.  If we ever need run_sync, we'll need to revisit this.
-      alias run run_async
-
       # Stop running terraform-runner job by stack_id
       #
       # @param stack_id [String] stack_id from the terraforn-runner job
       #
       # @return [Terraform::Runner::Response] Response object with result of terraform run
-      def stop_async(stack_id)
+      def stop(stack_id)
         cancel_stack_job(stack_id)
       end
 
@@ -55,7 +51,7 @@ module Terraform
       # @param stack_id [String] stack_id from the terraforn-runner job
       #
       # @return [Terraform::Runner::Response] Response object with result of terraform run
-      def fetch_result_by_stack_id(stack_id)
+      def status(stack_id)
         retrieve_stack_job(stack_id)
       end
 

--- a/lib/terraform/runner/response_async.rb
+++ b/lib/terraform/runner/response_async.rb
@@ -26,12 +26,12 @@ module Terraform
       def stop
         raise "No job running to stop" if !running?
 
-        Terraform::Runner.stop_async(@stack_id)
+        Terraform::Runner.stop(@stack_id)
       end
 
       # Re-Fetch async job's response
       def refresh_response
-        @response = Terraform::Runner.fetch_result_by_stack_id(@stack_id)
+        @response = Terraform::Runner.status(@stack_id)
 
         @response
       end

--- a/spec/lib/terraform/runner_spec.rb
+++ b/spec/lib/terraform/runner_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe(Terraform::Runner) do
     end
   end
 
-  context '.run_async hello-world' do
-    describe '.run_async with input_var' do
+  context '.run hello-world' do
+    describe '.run with input_var' do
       create_stub = nil
       retrieve_stub = nil
 
@@ -62,7 +62,7 @@ RSpec.describe(Terraform::Runner) do
       let(:input_vars) { {'name' => 'New World'} }
 
       it "start running hello-world terraform template" do
-        async_response = Terraform::Runner.run_async(input_vars, File.join(__dir__, "runner/data/hello-world"))
+        async_response = Terraform::Runner.run(input_vars, File.join(__dir__, "runner/data/hello-world"))
         expect(create_stub).to(have_been_requested.times(1))
 
         response = async_response.response
@@ -92,7 +92,7 @@ RSpec.describe(Terraform::Runner) do
       end
 
       it "is aliased as run" do
-        expect(Terraform::Runner.method(:run)).to(eq(Terraform::Runner.method(:run_async)))
+        expect(Terraform::Runner.method(:run)).to(eq(Terraform::Runner.method(:run)))
       end
     end
 
@@ -125,7 +125,7 @@ RSpec.describe(Terraform::Runner) do
       end
     end
 
-    describe 'Stop running .run_async template job' do
+    describe 'Stop running .run template job' do
       create_stub = nil
       retrieve_stub = nil
       cancel_stub = nil
@@ -166,7 +166,7 @@ RSpec.describe(Terraform::Runner) do
       let(:input_vars) { {} }
 
       it "start running, then stop the before it completes" do
-        async_response = Terraform::Runner.run_async(input_vars, File.join(__dir__, "runner/data/hello-world"))
+        async_response = Terraform::Runner.run(input_vars, File.join(__dir__, "runner/data/hello-world"))
         expect(create_stub).to(have_been_requested.times(1))
         expect(retrieve_stub).to(have_been_requested.times(0))
 
@@ -199,7 +199,7 @@ RSpec.describe(Terraform::Runner) do
   end
 
   context '.run with cloud credentials' do
-    describe '.run_async with amazon credential' do
+    describe '.run with amazon credential' do
       let(:amazon_cred) do
         params = {
           :userid         => "manageiq-aws",
@@ -259,7 +259,7 @@ RSpec.describe(Terraform::Runner) do
       let(:input_vars) { {} }
 
       it "start running terraform template with amazon credential" do
-        Terraform::Runner.run_async(
+        Terraform::Runner.run(
           input_vars,
           File.join(__dir__, "runner/data/hello-world"),
           :credentials => [amazon_cred]
@@ -268,7 +268,7 @@ RSpec.describe(Terraform::Runner) do
       end
     end
 
-    describe '.run_async with vSphere & ibmcloud credential' do
+    describe '.run with vSphere & ibmcloud credential' do
       let(:vsphere_cred) do
         params = {
           :userid   => "userid",
@@ -343,7 +343,7 @@ RSpec.describe(Terraform::Runner) do
       let(:input_vars) { {} }
 
       it "start running terraform template with vSphere & ibmcloud credentials" do
-        Terraform::Runner.run_async(
+        Terraform::Runner.run(
           input_vars,
           File.join(__dir__, "runner/data/hello-world"),
           :credentials => [vsphere_cred, ibmcloud_cred]


### PR DESCRIPTION
If the Terraform::Runner.run call fails there is no stack_id returned which means that any error message returned by the opentofu-runner API is lost.

Re-work how the API response is handled so that the error message is available if the initial call fails.

Fixes https://github.com/ManageIQ/manageiq-providers-embedded_terraform/issues/45
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
