### PR TITLE
Fix handling of template_path with trailing `/`

### DIFF
--- a/lib/terraform/runner.rb
+++ b/lib/terraform/runner.rb
@@ -165,7 +165,7 @@ module Terraform
       # encode zip of a template directory
       def encoded_zip_from_directory(template_path)
         dir_path = template_path # directory to be zipped
-        dir_path = path[0...-1] if dir_path.end_with?('/')
+        dir_path = dir_path[0...-1] if dir_path.end_with?('/')
 
         Tempfile.create(%w[opentofu-runner-payload .zip]) do |zip_file_path|
           _log.debug("Create #{zip_file_path}")

--- a/spec/lib/terraform/runner_spec.rb
+++ b/spec/lib/terraform/runner_spec.rb
@@ -76,6 +76,21 @@ RSpec.describe(Terraform::Runner) do
         expect(response.details).to(be_nil)
       end
 
+      it "handles trailing '/' in template path" do
+        async_response = Terraform::Runner.run_async(input_vars, File.join(__dir__, "runner/data/hello-world/"))
+        expect(create_stub).to(have_been_requested.times(1))
+
+        response = async_response.response
+        expect(retrieve_stub).to(have_been_requested.times(1))
+
+        expect(response.status).to(eq('IN_PROGRESS'), "terraform-runner failed with:\n#{response.status}")
+        expect(response.stack_id).to(eq(@hello_world_create_response['stack_id']))
+        expect(response.action).to(eq('CREATE'))
+        expect(response.stack_name).to(eq(@hello_world_create_response['stack_name']))
+        expect(response.message).to(be_nil)
+        expect(response.details).to(be_nil)
+      end
+
       it "is aliased as run" do
         expect(Terraform::Runner.method(:run)).to(eq(Terraform::Runner.method(:run_async)))
       end


### PR DESCRIPTION
Fixes
```
     NameError:
       undefined local variable or method `path' for Terraform::Runner:Class
     
               dir_path = path[0...-1] if dir_path.end_with?('/')
```

If you call `Terraform::Runner.run` with a path including a trailing `/`

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
