### PR TITLE
Fix some issues with opentofu-runner systemd service

### DIFF
--- a/app/models/opentofu_worker.rb
+++ b/app/models/opentofu_worker.rb
@@ -68,6 +68,7 @@ class OpentofuWorker < MiqWorker
       "DATABASE_NAME"         => database_configuration[:database],
       "DATABASE_USERNAME"     => database_configuration[:username],
       "MEMCACHE_SERVERS"      => ::Settings.session.memcache_server,
+      "PORT"                  => container_port,
       "OPENTOFU_RUNNER_IMAGE" => container_image
     }
   end

--- a/systemd/opentofu-runner.service
+++ b/systemd/opentofu-runner.service
@@ -5,7 +5,7 @@ WantedBy=opentofu-runner.target
 [Service]
 User=manageiq
 Group=manageiq
-ExecStartPre=/bin/rm -f /tmp/%n.cid
+ExecStartPre=/bin/rm -f %T/%N.pid %T/%N.cid
 ExecStartPre=loginctl enable-linger manageiq
 ExecStart=/usr/bin/podman run --conmon-pidfile %T/%N.pid --cidfile %T/%N.cid --cgroup-manager=cgroupfs --cgroups=no-conmon --log-driver=journald --replace --name=opentofu-runner --secret=opentofu-runner-secret --root=/var/www/miq/vmdb/data/containers/storage --env=DATABASE_HOSTNAME=${DATABASE_HOSTNAME} --env=DATABASE_NAME=${DATABASE_NAME} --env=DATABASE_USERNAME=${DATABASE_USERNAME} --env=MEMCACHE_SERVERS=${MEMCACHE_SERVERS} --volume=/var/lib/manageiq/opentofu-runner/certs:/opt/app-root/src/config/cert:z --expose=6000 --net=host $OPENTOFU_RUNNER_IMAGE
 ExecStop=/usr/bin/podman stop --ignore -t 30 --cidfile %T/%N.cid --cgroup-manager=cgroupfs --root=/var/www/miq/vmdb/data/containers/storage

--- a/systemd/opentofu-runner.service
+++ b/systemd/opentofu-runner.service
@@ -20,6 +20,6 @@ NotifyAccess=all
 SyslogIdentifier=%N
 ExecStartPre=/bin/rm -f %T/%N.cid
 ExecStartPre=loginctl enable-linger manageiq
-ExecStart=/usr/bin/podman run --name=opentofu-runner --cidfile=%T/%N.cid --replace --rm --cgroups=split --network=host --sdnotify=conmon -d -v /var/lib/manageiq/opentofu-runner/certs:/opt/app-root/src/config/cert:z --expose=6000 --env DATABASE_HOSTNAME=${DATABASE_HOSTNAME} --env DATABASE_NAME=${DATABASE_NAME} --env DATABASE_USERNAME=${DATABASE_USERNAME} --env MEMCACHE_SERVERS=${MEMCACHE_SERVERS} --secret opentofu-runner-secret --root /var/www/miq/vmdb/data/containers/storage ${OPENTOFU_RUNNER_IMAGE}
-ExecStop=/usr/bin/podman kill --root /var/www/miq/vmdb/data/containers/storage --cidfile=%T/%N.cid
+ExecStart=/usr/bin/podman run --name=opentofu-runner --cidfile=%T/%N.cid --replace --rm --cgroups=split --network=host --sdnotify=conmon -d -v /var/lib/manageiq/opentofu-runner/certs:/opt/app-root/src/config/cert:z --env DATABASE_HOSTNAME=${DATABASE_HOSTNAME} --env DATABASE_NAME=${DATABASE_NAME} --env DATABASE_USERNAME=${DATABASE_USERNAME} --env MEMCACHE_SERVERS=${MEMCACHE_SERVERS} --env PORT=${PORT} --expose=${PORT} --secret opentofu-runner-secret --root /var/www/miq/vmdb/data/containers/storage ${OPENTOFU_RUNNER_IMAGE}
+ExecStop=-/usr/bin/podman kill --root /var/www/miq/vmdb/data/containers/storage --cidfile=%T/%N.cid
 ExecStopPost=-/usr/bin/podman rm --root /var/www/miq/vmdb/data/containers/storage -v -f -i --cidfile=%T/%N.cid

--- a/systemd/opentofu-runner.service
+++ b/systemd/opentofu-runner.service
@@ -6,6 +6,7 @@ WantedBy=opentofu-runner.target
 User=manageiq
 Group=manageiq
 ExecStartPre=/bin/rm -f /tmp/%n.cid
+ExecStartPre=loginctl enable-linger manageiq
 ExecStart=/usr/bin/podman run --conmon-pidfile %T/%N.pid --cidfile %T/%N.cid --cgroup-manager=cgroupfs --cgroups=no-conmon --log-driver=journald --replace --name=opentofu-runner --secret=opentofu-runner-secret --root=/var/www/miq/vmdb/data/containers/storage --env=DATABASE_HOSTNAME=${DATABASE_HOSTNAME} --env=DATABASE_NAME=${DATABASE_NAME} --env=DATABASE_USERNAME=${DATABASE_USERNAME} --env=MEMCACHE_SERVERS=${MEMCACHE_SERVERS} --volume=/var/lib/manageiq/opentofu-runner/certs:/opt/app-root/src/config/cert:z --expose=6000 --net=host $OPENTOFU_RUNNER_IMAGE
 ExecStop=/usr/bin/podman stop --ignore -t 30 --cidfile %T/%N.cid --cgroup-manager=cgroupfs --root=/var/www/miq/vmdb/data/containers/storage
 ExecStopPost=/usr/bin/podman rm --ignore --cidfile %T/%N.cid --cgroup-manager=cgroupfs --root=/var/www/miq/vmdb/data/containers/storage

--- a/systemd/opentofu-runner.service
+++ b/systemd/opentofu-runner.service
@@ -1,17 +1,25 @@
 [Unit]
+Description=Opentofu Runner Container
+RequiresMountsFor=%t/containers
+RequiresMountsFor=/var/lib/manageiq/opentofu-runner/certs
 PartOf=opentofu-runner.target
+
 [Install]
 WantedBy=opentofu-runner.target
+
 [Service]
+Restart=on-failure
 User=manageiq
 Group=manageiq
-ExecStartPre=/bin/rm -f %T/%N.pid %T/%N.cid
-ExecStartPre=loginctl enable-linger manageiq
-ExecStart=/usr/bin/podman run --conmon-pidfile %T/%N.pid --cidfile %T/%N.cid --cgroup-manager=cgroupfs --cgroups=no-conmon --log-driver=journald --replace --name=opentofu-runner --secret=opentofu-runner-secret --root=/var/www/miq/vmdb/data/containers/storage --env=DATABASE_HOSTNAME=${DATABASE_HOSTNAME} --env=DATABASE_NAME=${DATABASE_NAME} --env=DATABASE_USERNAME=${DATABASE_USERNAME} --env=MEMCACHE_SERVERS=${MEMCACHE_SERVERS} --volume=/var/lib/manageiq/opentofu-runner/certs:/opt/app-root/src/config/cert:z --expose=6000 --net=host $OPENTOFU_RUNNER_IMAGE
-ExecStop=/usr/bin/podman stop --ignore -t 30 --cidfile %T/%N.cid --cgroup-manager=cgroupfs --root=/var/www/miq/vmdb/data/containers/storage
-ExecStopPost=/usr/bin/podman rm --ignore --cidfile %T/%N.cid --cgroup-manager=cgroupfs --root=/var/www/miq/vmdb/data/containers/storage
-ExecStopPost=/usr/bin/rm -f %T/%N.pid %T/%N.cid
-KillMode=none
-Type=simple
-Restart=always
 Slice=manageiq.slice
+Environment=PODMAN_SYSTEMD_UNIT=%n
+KillMode=mixed
+Delegate=yes
+Type=notify
+NotifyAccess=all
+SyslogIdentifier=%N
+ExecStartPre=/bin/rm -f %T/%N.cid
+ExecStartPre=loginctl enable-linger manageiq
+ExecStart=/usr/bin/podman run --name=opentofu-runner --cidfile=%T/%N.cid --replace --rm --cgroups=split --network=host --sdnotify=conmon -d -v /var/lib/manageiq/opentofu-runner/certs:/opt/app-root/src/config/cert:z --expose=6000 --env DATABASE_HOSTNAME=${DATABASE_HOSTNAME} --env DATABASE_NAME=${DATABASE_NAME} --env DATABASE_USERNAME=${DATABASE_USERNAME} --env MEMCACHE_SERVERS=${MEMCACHE_SERVERS} --secret opentofu-runner-secret --root /var/www/miq/vmdb/data/containers/storage ${OPENTOFU_RUNNER_IMAGE}
+ExecStop=/usr/bin/podman kill --root /var/www/miq/vmdb/data/containers/storage --cidfile=%T/%N.cid
+ExecStopPost=-/usr/bin/podman rm --root /var/www/miq/vmdb/data/containers/storage -v -f -i --cidfile=%T/%N.cid


### PR DESCRIPTION
Fix issues with --cgroup=systemd missing systemd user session
```
The cgroupv2 manager is set to systemd but there is no systemd user session available
For using systemd, you may need to log in using a user session
Alternatively, you can enable lingering with: `loginctl enable-linger 985` (possibly as root)
Falling back to --cgroup-manager=cgroupfs
```

Also move our service file closer to what would be generated by the `Quadlet` systemd generator in https://github.com/ManageIQ/manageiq-providers-embedded_terraform/pull/50

We aren't able to use that entirely yet but this ~~is inspired by~~ blatantly copies the resulting transient service file.

I split out the fix for each issue into a separate commit for easier review

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
