### PR TITLE
Parse dialog options as Extra Vars

### DIFF
--- a/app/models/service_terraform_template.rb
+++ b/app/models/service_terraform_template.rb
@@ -85,7 +85,7 @@ class ServiceTerraformTemplate < ServiceGeneric
     job_options[:extra_vars].try(:transform_values!) do |val|
       val.kind_of?(String) ? val : val[:default] # TODO: support Hash only
     end
-    # TODO: job_options.deep_merge!(parse_dialog_options) unless action == ResourceAction::RETIREMENT
+    job_options.deep_merge!(parse_dialog_options) unless action == ResourceAction::RETIREMENT
     job_options.deep_merge!(overrides)
     translate_credentials!(job_options)
 
@@ -95,6 +95,17 @@ class ServiceTerraformTemplate < ServiceGeneric
 
   def job_option_key(action)
     "#{action.downcase}_job_options".to_sym
+  end
+
+  def parse_dialog_options
+    dialog_options = options[:dialog] || {}
+
+    params = dialog_options.each_with_object({}) do |(attr, val), obj|
+      var_key = attr.sub(/^(password::)?dialog_/, '')
+      obj[var_key] = val
+    end
+
+    params.blank? ? {} : {:extra_vars => params}
   end
 
   def translate_credentials!(options)


### PR DESCRIPTION
When you have a dialog pass a value for a service order it comes in as:
```
options
{:dialog=>{"dialog_text_box_1"=>"hello world"}
```

We need to extract this and pass through to the Terraform::Runner as Extra Vars

With this change the Job options now look like:
```
 options:
  {:template_id=>4,
   :env_vars=>{},
   :input_vars=>{"execution_ttl"=>"", "extra_vars"=>{"text_box_1"=>"hello world"}, "verbosity"=>"0"},
   :credentials=>[3],
   :poll_interval=>1 minute,
   :git_checkout_tempdir=>"/tmp/embedded-terraform-runner-git20240603-334161-40j3os"},
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
