### PR TITLE
Fix Failed ServiceTerraformTemplate Provision finishing with Success Status

### DIFF
--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb
@@ -52,6 +52,6 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
   end
 
   def raw_status
-    Status.new(miq_task, nil)
+    Status.new(miq_task)
   end
 end

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/stack/status.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/stack/status.rb
@@ -1,8 +1,8 @@
 class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack::Status < OrchestrationStack::Status
   attr_accessor :task_status
 
-  def initialize(miq_task, reason)
-    super(miq_task.state, reason)
+  def initialize(miq_task)
+    super(miq_task.state, miq_task.message)
     self.task_status = miq_task.status
   end
 

--- a/app/models/service_terraform_template.rb
+++ b/app/models/service_terraform_template.rb
@@ -43,9 +43,12 @@ class ServiceTerraformTemplate < ServiceGeneric
   end
 
   def check_completed(action)
-    status  = stack(action).raw_status
-    done    = status.completed?
-    message = nil
+    status = stack(action).raw_status
+    done   = status.completed?
+
+    # If the stack is completed the message has to be nil otherwise the stack
+    # will get marked as failed
+    _, message = status.normalized_status unless status.succeeded?
     [done, message]
   rescue MiqException::MiqOrchestrationStackNotExistError, MiqException::MiqOrchestrationStatusError => err
     [true, err.message] # consider done with an error when exception is caught

--- a/spec/factories/orchestration_stack.rb
+++ b/spec/factories/orchestration_stack.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :terraform_stack,
+          :class  => "ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack",
+          :parent => :orchestration_stack
+end

--- a/spec/factories/service.rb
+++ b/spec/factories/service.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :service_terraform_template,
+          :class  => "ServiceTerraformTemplate",
+          :parent => :service
+end

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/stack_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/stack_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack do
+  describe "#raw_status" do
+    let(:stack) { FactoryBot.create(:terraform_stack, :miq_task => miq_task) }
+
+    context "with a running deployment" do
+      let(:miq_task) { FactoryBot.create(:miq_task, :state => "Running", :status => "Ok", :message => "process initiated") }
+
+      it "returns a status that is running" do
+        expect(stack.raw_status.completed?).to be_falsey
+      end
+    end
+
+    context "with a successful deployment" do
+      let(:miq_task) { FactoryBot.create(:miq_task, :state => "Finished", :status => "Ok", :message => "Task completed successfully") }
+
+      it "returns a status that is completed" do
+        expect(stack.raw_status.completed?).to be_truthy
+      end
+    end
+
+    context "with a failed deployment" do
+      let(:miq_task) { FactoryBot.create(:miq_task, :state => "Finished", :status => "Error", :message => "Failed to run template") }
+
+      it "returns a status that is failed" do
+        expect(stack.raw_status.failed?).to be_truthy
+      end
+
+      it "returns a normalized_status with a reason" do
+        expect(stack.raw_status.normalized_status).to eq(["failed", "Failed to run template"])
+      end
+    end
+  end
+end

--- a/spec/models/service_terraform_template_spec.rb
+++ b/spec/models/service_terraform_template_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe ServiceTerraformTemplate do
+  let!(:service) { FactoryBot.create(:service_terraform_template).tap { |s| s.add_resource!(stack, :name => "Provision") } }
+  let(:stack)    { FactoryBot.create(:terraform_stack) }
+
+  describe "#stack" do
+    it "returns the associated orchestration_stack" do
+      expect(service.stack("Provision")).to eq(stack)
+    end
+  end
+
+  describe "#check_completed" do
+    let(:stack) { FactoryBot.create(:terraform_stack, :miq_task => miq_task) }
+
+    context "with a running deployment" do
+      let(:miq_task) { FactoryBot.create(:miq_task, :state => "Running", :status => "Ok", :message => "process initiated") }
+
+      it "returns not done" do
+        done, _message = service.check_completed("Provision")
+        expect(done).to be_falsey
+      end
+    end
+
+    context "with a successful deployment" do
+      let(:miq_task) { FactoryBot.create(:miq_task, :state => "Finished", :status => "Ok", :message => "Task completed successfully") }
+
+      it "returns done" do
+        done, _message = service.check_completed("Provision")
+        expect(done).to be_truthy
+      end
+
+      it "returns a nil message" do
+        _done, message = service.check_completed("Provision")
+        expect(message).to be_nil
+      end
+    end
+
+    context "with a failed deployment" do
+      let(:miq_task) { FactoryBot.create(:miq_task, :state => "Finished", :status => "Error", :message => "Failed to run template") }
+
+      it "returns done" do
+        done, _message = service.check_completed("Provision")
+        expect(done).to be_truthy
+      end
+
+      it "returns the task message" do
+        _done, message = service.check_completed("Provision")
+        expect(message).to eq("Failed to run template")
+      end
+    end
+  end
+end


### PR DESCRIPTION
If an OrchestrationStack provision wasn't successful then the Status reason has to be non-nil otherwise it will be marked successful.

https://github.com/ManageIQ/manageiq-content/blob/master/content/automate/ManageIQ/Service/Generic/StateMachines/GenericLifecycle.class/__methods__/check_completed.rb#L62-L65

```
def check_completed(service)
  done, message = service.check_completed(service_action)
  if done
    if message.blank?
      @handle.root['ae_result'] = 'ok'
    else
       @handle.root['ae_result'] = 'error'
      ...
```

Before:
```
[----] I, [2024-06-05T14:26:40.115215#125175:9f9c]  INFO -- automation: Q-task_id([r1_service_template_provision_task_1]) Processing State=[check_completed]
[----] I, [2024-06-05T14:26:40.118592#125175:9f9c]  INFO -- automation: Q-task_id([r1_service_template_provision_task_1]) Updated namespace [Service/Generic/StateMachines/GenericLifecycle/check_completed  ManageIQ/Service/Generic/StateMachines]
[----] I, [2024-06-05T14:26:40.134748#125175:9f9c]  INFO -- automation: Q-task_id([r1_service_template_provision_task_1]) Invoking [inline] method [/ManageIQ/Service/Generic/StateMachines/GenericLifecycle/check_completed] with inputs [{}]
[----] I, [2024-06-05T14:26:40.164560#125175:9f9c]  INFO -- automation: Q-task_id([r1_service_template_provision_task_1]) <AEMethod [/ManageIQ/Service/Generic/StateMachines/GenericLifecycle/check_completed]> Starting 
[----] I, [2024-06-05T14:26:40.700821#125175:11d64]  INFO -- automation: Q-task_id([r1_service_template_provision_task_1]) <AEMethod check_completed> Starting check_completed
[----] I, [2024-06-05T14:26:40.821363#125175:11d64]  INFO -- automation: Q-task_id([r1_service_template_provision_task_1]) <AEMethod check_completed> Ending check_completed
[----] I, [2024-06-05T14:26:40.833077#125175:9f9c]  INFO -- automation: Q-task_id([r1_service_template_provision_task_1]) <AEMethod [/ManageIQ/Service/Generic/StateMachines/GenericLifecycle/check_completed]> Ending
[----] I, [2024-06-05T14:26:40.841456#125175:9f9c]  INFO -- automation: Q-task_id([r1_service_template_provision_task_1]) Processed State=[check_completed] with Result=[ok]
```

![image](https://github.com/ManageIQ/manageiq-providers-embedded_terraform/assets/12851112/b95731bc-4bdb-4805-ae49-86162c591f62)


After:
```
[----] I, [2024-06-05T14:56:23.554214#156914:9f9c]  INFO -- automation: Q-task_id([r2_service_template_provision_task_2]) Processing State=[check_completed]
[----] I, [2024-06-05T14:56:23.560084#156914:9f9c]  INFO -- automation: Q-task_id([r2_service_template_provision_task_2]) Updated namespace [Service/Generic/StateMachines/GenericLifecycle/check_completed  ManageIQ/Service/Generic/StateMachines]
[----] I, [2024-06-05T14:56:23.588664#156914:9f9c]  INFO -- automation: Q-task_id([r2_service_template_provision_task_2]) Invoking [inline] method [/ManageIQ/Service/Generic/StateMachines/GenericLifecycle/check_completed] with inputs [{}]
[----] I, [2024-06-05T14:56:23.631927#156914:9f9c]  INFO -- automation: Q-task_id([r2_service_template_provision_task_2]) <AEMethod [/ManageIQ/Service/Generic/StateMachines/GenericLifecycle/check_completed]> Starting 
[----] I, [2024-06-05T14:56:24.233516#156914:1241c]  INFO -- automation: Q-task_id([r2_service_template_provision_task_2]) <AEMethod check_completed> Starting check_completed
[----] E, [2024-06-05T14:56:24.242156#156914:1241c] ERROR -- automation: Q-task_id([r2_service_template_provision_task_2]) <AEMethod check_completed> Error in check completed: Failed to run template
[----] I, [2024-06-05T14:56:24.255691#156914:1241c]  INFO -- automation: Q-task_id([r2_service_template_provision_task_2]) <AEMethod check_completed> Ending check_completed
[----] I, [2024-06-05T14:56:24.265645#156914:9f9c]  INFO -- automation: Q-task_id([r2_service_template_provision_task_2]) <AEMethod [/ManageIQ/Service/Generic/StateMachines/GenericLifecycle/check_completed]> Ending
[----] I, [2024-06-05T14:56:24.271833#156914:9f9c]  INFO -- automation: Q-task_id([r2_service_template_provision_task_2]) Processed State=[check_completed] with Result=[error]
```

![image](https://github.com/ManageIQ/manageiq-providers-embedded_terraform/assets/12851112/734de295-1c39-4a1e-bd2a-9d66c8b2f0a2)


<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
