### PR TITLE
Check embedded_terraform role in `Button::EmbeddedTerraform#disabled?`

### DIFF
--- a/app/helpers/application_helper/button/embedded_terraform.rb
+++ b/app/helpers/application_helper/button/embedded_terraform.rb
@@ -1,7 +1,10 @@
 class ApplicationHelper::Button::EmbeddedTerraform < ApplicationHelper::Button::Basic
   def disabled?
-    if Rbac.filtered(ManageIQ::Providers::EmbeddedTerraform::AutomationManager.all).empty?
+    if !MiqRegion.my_region.role_active?('embedded_terraform')
+      @error_message = _("Embedded Terraform Role is not enabled.")
+    elsif Rbac.filtered(ManageIQ::Providers::EmbeddedTerraform::AutomationManager.all).empty?
       @error_message = _("User isn't allowed to use the Embedded Terraform provider.")
     end
+    @error_message.present?
   end
 end


### PR DESCRIPTION
Prevent the user from adding credentials/repositories if the embedded_terraform role is disabled.

This is similar to what embedded_ansible's button class does https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/helpers/application_helper/button/embedded_ansible.rb

I dropped the provider check because a.) we seed embedded-terraform unconditionally and b.) there is no Provider and the EmbeddedTerraform::AutomationManager check would catch it if we didn't seed

NOTE it seems like if the entire dropdown is disabled you don't see the tooltip that says why it is disabled but that's an issue with all of these

With the role disabled:
![Screenshot from 2024-06-06 13-21-02](https://github.com/ManageIQ/manageiq-providers-embedded_terraform/assets/12851112/4ed8bc31-8105-425b-82fb-8bf1c14e5bdc)
![Screenshot from 2024-06-06 13-21-26](https://github.com/ManageIQ/manageiq-providers-embedded_terraform/assets/12851112/8132fbed-18f3-4585-ae7d-930ab33916bc)

With the role enabled:
![Screenshot from 2024-06-06 13-23-57](https://github.com/ManageIQ/manageiq-providers-embedded_terraform/assets/12851112/b6935c7e-89b1-4e6a-8ba7-077f98226893)
![Screenshot from 2024-06-06 13-24-08](https://github.com/ManageIQ/manageiq-providers-embedded_terraform/assets/12851112/aa6e1ff5-80b1-4452-ae13-f549fe92a039)


<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
