### PR TITLE
Adding environment variable for offline or airgap env

### DIFF
--- a/app/models/opentofu_worker.rb
+++ b/app/models/opentofu_worker.rb
@@ -74,7 +74,9 @@ class OpentofuWorker < MiqWorker
       "DATABASE_USERNAME"     => database_configuration[:username],
       "MEMCACHE_SERVERS"      => ::Settings.session.memcache_server,
       "PORT"                  => container_port,
-      "OPENTOFU_RUNNER_IMAGE" => container_image
+      "OPENTOFU_RUNNER_IMAGE" => container_image,
+      "LOG4JS_LEVEL"          => ::Settings.log.level_embedded_terraform,
+      "TF_OFFLINE"            => worker_settings[:opentofu_offline]
     }
   end
 

--- a/app/models/opentofu_worker.rb
+++ b/app/models/opentofu_worker.rb
@@ -82,7 +82,7 @@ class OpentofuWorker < MiqWorker
     env_var_array = definition[:spec][:template][:spec][:containers][0][:env]
     env_var_array.detect { |env| env[:name] == "HOME" }&.[]=(:value, "/home/node")
 
-    definition[:spec][:template][:spec][:containers][0][:env] << {:name => "LOG4JS_LEVEL", :value => :level_embedded_terraform}
+    definition[:spec][:template][:spec][:containers][0][:env] << {:name => "LOG4JS_LEVEL", :value => Settings.log.level_embedded_terraform}
     definition[:spec][:template][:spec][:containers][0][:env] << {:name => "TF_OFFLINE", :value => worker_settings[:opentofu_offline]}
 
     # these volume mounts are require by terraform runner to create the stack, mentioned it as {} so that it can be writable

--- a/app/models/opentofu_worker.rb
+++ b/app/models/opentofu_worker.rb
@@ -83,7 +83,7 @@ class OpentofuWorker < MiqWorker
     env_var_array.detect { |env| env[:name] == "HOME" }&.[]=(:value, "/home/node")
 
     definition[:spec][:template][:spec][:containers][0][:env] << {:name => "LOG4JS_LEVEL", :value => "info"}
-    definition[:spec][:template][:spec][:containers][0][:env] << {:name => "AIRGAP_OFFLINE", :value => "false"}
+    definition[:spec][:template][:spec][:containers][0][:env] << {:name => "TF_OFFLINE", :value => "false"}
 
     # these volume mounts are require by terraform runner to create the stack, mentioned it as {} so that it can be writable
     definition[:spec][:template][:spec][:containers].first[:volumeMounts] << {:name => "terraform-bin-empty", :mountPath => "/home/node/terraform/bin"}

--- a/app/models/opentofu_worker.rb
+++ b/app/models/opentofu_worker.rb
@@ -82,6 +82,9 @@ class OpentofuWorker < MiqWorker
     env_var_array = definition[:spec][:template][:spec][:containers][0][:env]
     env_var_array.detect { |env| env[:name] == "HOME" }&.[]=(:value, "/home/node")
 
+    definition[:spec][:template][:spec][:containers][0][:env] << {:name => "LOG4JS_LEVEL", :value => "info"}
+    definition[:spec][:template][:spec][:containers][0][:env] << {:name => "AIRGAP_OFFLINE", :value => "false"}
+
     # these volume mounts are require by terraform runner to create the stack, mentioned it as {} so that it can be writable
     definition[:spec][:template][:spec][:containers].first[:volumeMounts] << {:name => "terraform-bin-empty", :mountPath => "/home/node/terraform/bin"}
     definition[:spec][:template][:spec][:volumes] << {:name => "stacks-empty", :emptyDir => {}}

--- a/app/models/opentofu_worker.rb
+++ b/app/models/opentofu_worker.rb
@@ -5,6 +5,11 @@ class OpentofuWorker < MiqWorker
   self.rails_worker          = false
   self.maximum_workers_count = 1
 
+  self.worker_settings_paths = [
+    %i[log level_embedded_terraform],
+    %i[workers worker_base opentofu_worker]
+  ]
+
   OPENTOFU_RUNTIME_DIR = "/var/lib/manageiq/opentofu-runner".freeze
   SERVICE_PORT = 6000
 

--- a/app/models/opentofu_worker.rb
+++ b/app/models/opentofu_worker.rb
@@ -82,8 +82,8 @@ class OpentofuWorker < MiqWorker
     env_var_array = definition[:spec][:template][:spec][:containers][0][:env]
     env_var_array.detect { |env| env[:name] == "HOME" }&.[]=(:value, "/home/node")
 
-    definition[:spec][:template][:spec][:containers][0][:env] << {:name => "LOG4JS_LEVEL", :value => "info"}
-    definition[:spec][:template][:spec][:containers][0][:env] << {:name => "TF_OFFLINE", :value => "false"}
+    definition[:spec][:template][:spec][:containers][0][:env] << {:name => "LOG4JS_LEVEL", :value => :level_embedded_terraform}
+    definition[:spec][:template][:spec][:containers][0][:env] << {:name => "TF_OFFLINE", :value => worker_settings[:opentofu_offline]}
 
     # these volume mounts are require by terraform runner to create the stack, mentioned it as {} so that it can be writable
     definition[:spec][:template][:spec][:containers].first[:volumeMounts] << {:name => "terraform-bin-empty", :mountPath => "/home/node/terraform/bin"}

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,3 +19,4 @@
     :opentofu_worker:
       :container_image: docker.io/manageiq/opentofu-runner:latest
       :heartbeat_timeout:
+      :opentofu_offline: false


### PR DESCRIPTION
This PR will help us add environment variables in opentofu deployment. 
We are adding 2 environment variables here
LOG4JS_LEVEL -> This will help us update log level in case we want to do further debugging
AIRGAP_OFFLINE -> This will help terraform runner to understand if customer is running in airgap environment