### PR TITLE
Fix credential type text

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -3,4 +3,6 @@ en:
     model:
       ManageIQ::Providers::EmbeddedTerraform::AutomationManager::ConfigurationScriptSource:  Repository (Embedded Terraform)
       ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Credential:                 Credential (Embedded Terraform)
+      ManageIQ::Providers::EmbeddedTerraform::AutomationManager::ScmCredential:              Credential (SCM)
+      ManageIQ::Providers::EmbeddedTerraform::AutomationManager::AmazonCredential:           Credential (Amazon)
       ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Template:                   Template (Embedded Terraform)


### PR DESCRIPTION
Fix credential type text

Before:
<img width="1415" alt="Screenshot 2024-07-11 at 11 50 28 AM" src="https://github.com/ManageIQ/manageiq-providers-embedded_terraform/assets/32444791/99433beb-feda-427a-9aa7-5810326902c9">

After:
<img width="1412" alt="Screenshot 2024-07-11 at 11 49 27 AM" src="https://github.com/ManageIQ/manageiq-providers-embedded_terraform/assets/32444791/c0fff58a-5d0f-4601-af6d-91f8607e2733">
