### PR TITLE
Add templates payload to summary page

### DIFF
--- a/app/views/embedded_terraform_template/show.html.haml
+++ b/app/views/embedded_terraform_template/show.html.haml
@@ -1,2 +1,3 @@
 #main_div
   = render :partial => 'layouts/textual_groups_generic'
+  = react('WorkflowPayload', {:recordId => params[:id].to_s})


### PR DESCRIPTION
Add templates payload to summary page

<img width="1290" alt="Screenshot 2024-07-11 at 12 39 35 PM" src="https://github.com/ManageIQ/manageiq-providers-embedded_terraform/assets/32444791/412a1935-2610-4943-8ce7-98e0db1e21b1">
