### PR TITLE
Fix terraform template name

### DIFF
--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/configuration_script_source.rb
@@ -46,13 +46,12 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::ConfigurationSc
   # eg.
   #   https://github.ibm.com/manoj-puthran/sample-scripts/tree/v2.0/terraform/templates/hello-world
   #       is converted as
-  #   "hello-world(v2.0):github.ibm.com/manoj-puthran/sample-scripts/terraform/templates"
-  def self.template_name_from_git_repo_url(git_repo_url, branch_name, relative_path)
+  #   templates/hello-world
+  def self.template_name_from_git_repo_url(git_repo_url, relative_path)
     temp_url = git_repo_url
     # URI library cannot handle git urls, so just convert it to a standard url.
     temp_url = temp_url.sub(':', '/').sub('git@', 'https://') if temp_url.start_with?('git@')
     temp_uri = URI.parse(temp_url)
-    hostname = temp_uri.hostname
     path = temp_uri.path
     path = path[0...-4] if path.end_with?('.git')
     path = path[0...-5] if path.end_with?('.git/')
@@ -64,7 +63,7 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::ConfigurationSc
       basename = File.basename(relative_path)
       parent_path = File.dirname(relative_path)
     end
-    "#{basename}(#{branch_name}):#{hostname}#{path}/#{parent_path}"
+    "#{parent_path}/#{basename}"
   end
 
   private
@@ -87,7 +86,7 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::ConfigurationSc
               .select            { |_dir, files| files.any? { |f| f.end_with?(".tf", ".tf.json") } }
               .transform_values! { |files| files.map { |f| File.basename(f) } }
               .each do |parent_dir, files|
-        name = self.class.template_name_from_git_repo_url(git_repository.url, scm_branch, parent_dir)
+        name = self.class.template_name_from_git_repo_url(git_repository.url, parent_dir)
 
         # TODO: add parsing for input/output vars
         input_vars  = nil

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/configuration_script_source_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/configuration_script_source_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe(ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Config
         names = names_and_payloads.collect(&:first)
         payloads = names_and_payloads.collect(&:second)
 
-        expect(names.first).to(eq("hello_world_local(master):#{local_repo}/"))
+        expect(names.first).to(eq("/hello_world_local"))
 
         expected_hash = {
           "relative_path" => File.dirname(*repo_dir_structure),
@@ -114,7 +114,7 @@ RSpec.describe(ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Config
           names = names_and_payloads.collect(&:first)
           payloads = names_and_payloads.collect(&:second)
 
-          expect(names.first).to(eq("hello-world(master):#{nested_repo}/templates"))
+          expect(names.first).to(eq("templates/hello-world"))
 
           expected_hash = {
             "relative_path" => File.dirname(*nested_repo_structure),
@@ -167,8 +167,8 @@ RSpec.describe(ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Config
           expect(names).to(
             eq(
               [
-                "hello-world(master):#{multiple_templates_repo}/templates",
-                "single-vm(master):#{multiple_templates_repo}/templates"
+                "templates/hello-world",
+                "templates/single-vm"
               ]
             )
           )
@@ -213,7 +213,7 @@ RSpec.describe(ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Config
           names = names_and_payloads.collect(&:first)
           payloads = names_and_payloads.collect(&:second)
 
-          expect(names.first).to(eq("hello-world(master):#{nested_repo}/templates"))
+          expect(names.first).to(eq("templates/hello-world"))
 
           files = JSON.parse(payloads.first)["files"]
 
@@ -241,15 +241,15 @@ RSpec.describe(ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Config
           record           = build_record
 
           names = record.configuration_script_payloads.pluck(:name)
-          expect(names).to(match_array(["hello-world(master):#{nested_repo}/templates"]))
+          expect(names).to(match_array(["templates/hello-world"]))
         end
       end
     end
 
     describe "#template_name_from_git_repo_url" do
-      let(:git_url_branch_path)   { ["git@example.com:manoj-puthran/sample-scripts.git", "v2.0", "terraform/templates/hello-world"] }
-      let(:https_url_branch_path) { ["https://example.com/manoj-puthran/sample-scripts.git", "v2.0", "terraform/templates/hello-world"] }
-      let(:expected_result)       { "hello-world(v2.0):example.com/manoj-puthran/sample-scripts/terraform/templates" }
+      let(:git_url_branch_path)   { ["git@example.com:manoj-puthran/sample-scripts.git", "terraform/templates/hello-world"] }
+      let(:https_url_branch_path) { ["https://example.com/manoj-puthran/sample-scripts.git", "terraform/templates/hello-world"] }
+      let(:expected_result)       { "terraform/templates/hello-world" }
 
       it "supports https urls" do
         expect(described_class.template_name_from_git_repo_url(*https_url_branch_path)).to(eq(expected_result))
@@ -279,7 +279,7 @@ RSpec.describe(ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Config
           names = names_and_payloads.collect(&:first)
           payloads = names_and_payloads.collect(&:second)
 
-          expect(names.first).to(eq("hello_world_local(other_branch):#{local_repo}/"))
+          expect(names.first).to(eq("/hello_world_local"))
 
           expected_hash = {
             "relative_path" => File.dirname(*repo_dir_structure),


### PR DESCRIPTION
Fix terraform template name.

Before:
![Screenshot 2024-07-11 at 4 45 04 PM](https://github.com/ManageIQ/manageiq-providers-embedded_terraform/assets/32444791/f7360beb-0756-4a6b-af3c-620b06b8f252)

After:
<img width="1429" alt="Screenshot 2024-07-11 at 4 53 04 PM" src="https://github.com/ManageIQ/manageiq-providers-embedded_terraform/assets/32444791/56332f77-337c-4571-83d4-d26d6b297517">
<img width="897" alt="Screenshot 2024-07-11 at 4 55 54 PM" src="https://github.com/ManageIQ/manageiq-providers-embedded_terraform/assets/32444791/dd9bc2ab-3e4a-4f84-b237-26fa942ecf35">
