### PR TITLE
Always create opentofu_worker miq_workers record

### DIFF
--- a/app/models/opentofu_worker.rb
+++ b/app/models/opentofu_worker.rb
@@ -25,6 +25,10 @@ class OpentofuWorker < MiqWorker
     MiqWorkerType::KILL_PRIORITY_GENERIC_WORKERS
   end
 
+  def self.start_worker(*params)
+    create_worker_record(*params).tap(&:start)
+  end
+
   def worker_deployment_name
     @worker_deployment_name ||= "#{deployment_prefix}opentofu-runner"
   end


### PR DESCRIPTION
Eventually the goal is for MiqServer to create worker records for all worker types but for now it is simpler to do this specifically for the OpentofuWorker

This still depends on a change in core to assign a system_uid (pod_name) to the worker record that gets created, but simplifies everything else by not changing how existing Rails workers with run_single_worker.rb work.

Required for https://github.com/ManageIQ/manageiq/pull/23112

Fixes https://github.com/ManageIQ/manageiq-providers-embedded_terraform/issues/67
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
