### PR TITLE
Fix `Terraform::Runner.available?`

### DIFF
--- a/lib/terraform/runner.rb
+++ b/lib/terraform/runner.rb
@@ -9,7 +9,7 @@ module Terraform
       def available?
         return @available if defined?(@available)
 
-        response = terraform_runner_client.get('api/ping')
+        response = terraform_runner_client.get('ping')
         @available = response.status == 200
       rescue
         @available = false

--- a/spec/lib/terraform/runner_spec.rb
+++ b/spec/lib/terraform/runner_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe(Terraform::Runner) do
     before do
       ENV["TERRAFORM_RUNNER_URL"] = "https://1.2.3.4:7000"
 
-      stub_request(:get, "https://1.2.3.4:7000/api/ping")
+      stub_request(:get, "https://1.2.3.4:7000/ping")
         .to_return(:status => 200, :body => {'count' => 0}.to_json)
     end
 


### PR DESCRIPTION
The endpoint for opentofu-runner ping is just `/ping` not `/api/ping`:

With the opentofu-runner running:
```
# systemctl status opentofu-runner
● opentofu-runner.service - Opentofu Runner Container
     Loaded: loaded (/usr/lib/systemd/system/opentofu-runner.service; enabled; preset: disabled)
    Drop-In: /usr/lib/systemd/system/opentofu-runner.service.d
             └─override.conf
     Active: active (running) since Fri 2024-08-30 10:28:33 EDT; 47min ago
```

Running `Terraform::Runner.available?`:
```
irb(main):001:0> Terraform::Runner.available?
=> false
```

After this change:
```
irb(main):001:0> Terraform::Runner.available?
=> true
```

We can see from the output that the path is just `/ping` from the `journalctl -u opentofu-runner` output:
```
opentofu-runner[6767]: Server is running at https://[::1]:6000
opentofu-runner[6767]: Try https://[::1]:6000/ping
```

This was added in https://github.com/ManageIQ/manageiq-providers-embedded_terraform/pull/14 I'm not sure if the opentofu-runner image changed or if it was just always the wrong ping path.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
