### PR TITLE
OpentofuWorker#stop_worker should delete the pod

### DIFF
--- a/app/models/opentofu_worker.rb
+++ b/app/models/opentofu_worker.rb
@@ -49,6 +49,13 @@ class OpentofuWorker < MiqWorker
     }
   end
 
+  # The opentofu-runner pod is a service worker but isn't scalable so the
+  # stop_container method should delete_container_objects like a deployment-per-worker
+  # not scale_deployment like a service_worker.
+  def stop_container
+    delete_container_objects
+  end
+
   private
 
   # There can only be a single instance running so the unit name can just be


### PR DESCRIPTION
OpentofuWorker is a ServiceWorker but also isn't scalable (aka it is a deployment-per-worker type).

This means that when we want to stop an OpentofuWorker we have to delete the deployment where previously it would scale the deployment to 1 and not actually delete the pod.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
