### PR TITLE
Remove useless Dir.chdir in Terraform::Runner

### DIFF
--- a/lib/terraform/runner.rb
+++ b/lib/terraform/runner.rb
@@ -170,8 +170,7 @@ module Terraform
         Tempfile.create(%w[opentofu-runner-payload .zip]) do |zip_file_path|
           _log.debug("Create #{zip_file_path}")
           Zip::File.open(zip_file_path, Zip::File::CREATE) do |zipfile|
-            Dir.chdir(dir_path)
-            Dir.glob("**/*").select { |fn| File.file?(fn) }.each do |file|
+            Dir.glob(File.join(dir_path, "/**/*")).select { |fn| File.file?(fn) }.each do |file|
               _log.debug("Adding #{file}")
               zipfile.add(file.sub("#{dir_path}/", ''), file)
             end


### PR DESCRIPTION
Dir.glob returns full file pathnames that have the dir_path stipped before adding to the zipfile anyway so the Dir.chdir is entirely useless here.

Also potentially causing issues with simplecov running later on https://github.com/ManageIQ/manageiq-providers-embedded_terraform/actions/runs/11108852227/job/30862783858#step:7:201
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
