### PR TITLE
Add instructions on running opentofu-runner locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,34 @@ See the section on plugins in the [ManageIQ Developer Setup](http://manageiq.org
 
 For quick local setup run `bin/setup`, which will clone the core ManageIQ repository under the *spec* directory and setup necessary config files. If you have already cloned it, you can run `bin/update` to bring the core ManageIQ code up to date.
 
+### Running Opentofu Runner locally
+
+First ensure that you have the opentofu-runner image pulled locally:
+```
+docker pull docker.io/manageiq/opentofu-runner:latest
+```
+
+If your database connection requires a password then create a secret:
+```
+echo '{"DATABASE_PASSWORD":"mypassword"}' | docker secret create opentofu-runner-secret -
+```
+
+And add `--secret opentofu-runner-secret` to the command below
+
+Now you can start your opentofu-runner:
+```
+docker run --name=opentofu-runner --rm --network=host --env NODE_ENV=development --env DATABASE_HOSTNAME=localhost --env DATABASE_NAME=vmdb_development --env DATABASE_USERNAME=root --env MEMCACHE_SERVERS=127.0.0.1:11211 --env PORT=6000 --expose=6000 docker.io/manageiq/opentofu-runner:latest
+```
+
+Verify that everything is working by checking `Terraform::Runner.available?` with a rails console:
+```
+$ TERRAFORM_RUNNER_URL=http://localhost:6000 rails c
+>> Terraform::Runner.available?
+=> true
+```
+
+To stop the opentofu-runner `docker stop opentofu-runner` in another terminal.
+
 ## License
 
 The gem is available as open source under the terms of the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION
If you need to run the opentofu-runner locally for development without a full podified / systemd runtime you can run just the docker container directly.

This is now needed now in order to sync a terraform repo in order to parse variables.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
