### PR TITLE
[WIP] Move OPENTOFU_RUNNER_IMAGE to /etc/defaults

### DIFF
--- a/app/models/opentofu_worker.rb
+++ b/app/models/opentofu_worker.rb
@@ -69,7 +69,7 @@ class OpentofuWorker < MiqWorker
   end
 
   def container_image
-    ENV["OPENTOFU_RUNNER_IMAGE"] || worker_settings[:container_image] || default_image
+    ENV["OPENTOFU_RUNNER_IMAGE"] || default_image
   end
 
   def enable_systemd_unit
@@ -91,8 +91,7 @@ class OpentofuWorker < MiqWorker
       "DATABASE_HOSTNAME"     => database_configuration[:host],
       "DATABASE_NAME"         => database_configuration[:database],
       "DATABASE_USERNAME"     => database_configuration[:username],
-      "MEMCACHE_SERVERS"      => ::Settings.session.memcache_server,
-      "OPENTOFU_RUNNER_IMAGE" => container_image
+      "MEMCACHE_SERVERS"      => ::Settings.session.memcache_server
     }
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,6 +17,5 @@
 :workers:
   :worker_base:
     :opentofu_worker:
-      :container_image: docker.io/manageiq/opentofu-runner:latest
       :heartbeat_timeout:
       :opentofu_offline: false

--- a/systemd/opentofu-runner.service
+++ b/systemd/opentofu-runner.service
@@ -13,6 +13,7 @@ User=manageiq
 Group=manageiq
 Slice=manageiq.slice
 Environment=PODMAN_SYSTEMD_UNIT=%n
+EnvironmentFile=/etc/default/manageiq-container-images.properties
 KillMode=mixed
 Delegate=yes
 Type=notify


### PR DESCRIPTION
I'm not sure what we will end up calling this properties file, but this shows how we could have a file with all of the images as env vars:
```
/etc/defaults/manageiq-container-images.properties
OPENTOFU_RUNNER_IMAGE=docker.io/manageiq/opentofu-runner:latest
...
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->

