### PR TITLE
Add dialog fields based on terraform type constraints

### DIFF
--- a/app/models/dialog/terraform_template_service_dialog.rb
+++ b/app/models/dialog/terraform_template_service_dialog.rb
@@ -30,6 +30,8 @@ class Dialog
     JSONSTR_LIST_REGEX = '^\[[\W\w]*\]$'.freeze   # list of strings or objects
     JSONSTR_OBJECT_REGEX = '^\{[\W\w]*\}$'.freeze # map or object
 
+    NUMBER_REGEX = '^[0-9]+$|^[0-9]+[\.]{1}[0-9]+$'.freeze # integer or decimal point number
+
     private
 
     def add_template_variables_group(tab, position, terraform_template)
@@ -56,6 +58,10 @@ class Dialog
           when "boolean"
             add_check_box_field(
               key, value, dialog_group, index, label, description, readonly
+            )
+          when "number"
+            add_number_variable_field(
+              key, value, dialog_group, index, label, description, required, readonly
             )
           when "map"
             add_json_variable_field(
@@ -126,6 +132,28 @@ class Dialog
         :validator_type    => 'regex',
         :validator_rule    => is_list ? JSONSTR_LIST_REGEX : JSONSTR_OBJECT_REGEX,
         :validator_message => "This field value must be a JSON #{is_list ? 'List' : 'Object or Map'}"
+      )
+    end
+
+    def add_number_variable_field(key, value, group, position, label, description, required, read_only)
+      description = key if description.blank?
+
+      group.dialog_fields.build(
+        :type              => 'DialogFieldTextBox',
+        :name              => key.to_s,
+        :data_type         => 'string',
+        :display           => 'edit',
+        :required          => required,
+        :default_value     => value,
+        :label             => label,
+        :description       => description,
+        :reconfigurable    => true,
+        :position          => position,
+        :dialog_group      => group,
+        :read_only         => read_only,
+        :validator_type    => 'regex',
+        :validator_rule    => NUMBER_REGEX,
+        :validator_message => "This field value must be a number"
       )
     end
 

--- a/app/models/dialog/terraform_template_service_dialog.rb
+++ b/app/models/dialog/terraform_template_service_dialog.rb
@@ -42,17 +42,23 @@ class Dialog
         :position => position
       ).tap do |dialog_group|
         input_vars.each_with_index do |(var_info), index|
-          key, value, required, readonly, hidden, label, description = var_info.values_at(
-            "name", "default", "required", "immutable", "hidden", "label", "description"
+          key, value, required, readonly, hidden, label, description, type = var_info.values_at(
+            "name", "default", "required", "immutable", "hidden", "label", "description", "type"
           )
-          # TODO: use these when adding variable field
-          # type, secured = var_info.values_at("type", "secured")
+          # TODO: use 'hidden' & 'secured' attributes, when adding variable field
 
           next if hidden
 
-          add_variable_field(
-            key, value, dialog_group, index, label, description, required, readonly
-          )
+          case type
+          when "boolean"
+            add_check_box_field(
+              key, value, dialog_group, index, label, description, readonly
+            )
+          else
+            add_variable_field(
+              key, value, dialog_group, index, label, description, required, readonly
+            )
+          end
         end
       end
     end
@@ -87,6 +93,29 @@ class Dialog
         :dialog_group   => group,
         :read_only      => read_only
       )
+    end
+
+    def add_check_box_field(key, value, group, position, label, description, read_only)
+      value = to_boolean(value)
+      description = key if description.blank?
+
+      group.dialog_fields.build(
+        :type           => "DialogFieldCheckBox",
+        :name           => key.to_s,
+        :data_type      => "boolean",
+        :default_value  => value,
+        :label          => label,
+        :description    => description,
+        :reconfigurable => true,
+        :position       => position,
+        :dialog_group   => group,
+        :read_only      => read_only
+      )
+    end
+
+    def to_boolean(value)
+      require 'active_model/type'
+      ActiveModel::Type::Boolean.new.cast(value)
     end
   end
 end

--- a/app/models/dialog/terraform_template_service_dialog.rb
+++ b/app/models/dialog/terraform_template_service_dialog.rb
@@ -54,6 +54,14 @@ class Dialog
             add_check_box_field(
               key, value, dialog_group, index, label, description, readonly
             )
+          when "map"
+            add_json_variable_field(
+              key, value, dialog_group, index, label, description, required, readonly, :is_list => false
+            )
+          when "list"
+            add_json_variable_field(
+              key, value, dialog_group, index, label, description, required, readonly, :is_list => true
+            )
           else
             add_variable_field(
               key, value, dialog_group, index, label, description, required, readonly
@@ -92,6 +100,32 @@ class Dialog
         :position       => position,
         :dialog_group   => group,
         :read_only      => read_only
+      )
+    end
+
+    JSONSTR_LIST_REGEX = '^\[[\W\w]*\]$'.freeze   # list of strings or objects
+    JSONSTR_OBJECT_REGEX = '^\{[\W\w]*\}$'.freeze # map or object
+
+    def add_json_variable_field(key, value, group, position, label, description, required, read_only, is_list: false)
+      value = JSON.pretty_generate(value) if [Hash, Array].include?(value.class)
+      description = key if description.blank?
+
+      group.dialog_fields.build(
+        :type              => 'DialogFieldTextAreaBox',
+        :name              => key.to_s,
+        :data_type         => 'string',
+        :display           => 'edit',
+        :required          => required,
+        :default_value     => value,
+        :label             => label,
+        :description       => description,
+        :reconfigurable    => true,
+        :position          => position,
+        :dialog_group      => group,
+        :read_only         => read_only,
+        :validator_type    => 'regex',
+        :validator_rule    => is_list ? JSONSTR_LIST_REGEX : JSONSTR_OBJECT_REGEX,
+        :validator_message => "must be JSON #{is_list ? 'List' : 'Object or Map'}"
       )
     end
 

--- a/app/models/dialog/terraform_template_service_dialog.rb
+++ b/app/models/dialog/terraform_template_service_dialog.rb
@@ -125,7 +125,7 @@ class Dialog
         :read_only         => read_only,
         :validator_type    => 'regex',
         :validator_rule    => is_list ? JSONSTR_LIST_REGEX : JSONSTR_OBJECT_REGEX,
-        :validator_message => "must be JSON #{is_list ? 'List' : 'Object or Map'}"
+        :validator_message => "This field value must be a JSON #{is_list ? 'List' : 'Object or Map'}"
       )
     end
 

--- a/app/models/dialog/terraform_template_service_dialog.rb
+++ b/app/models/dialog/terraform_template_service_dialog.rb
@@ -27,6 +27,9 @@ class Dialog
       end
     end
 
+    JSONSTR_LIST_REGEX = '^\[[\W\w]*\]$'.freeze   # list of strings or objects
+    JSONSTR_OBJECT_REGEX = '^\{[\W\w]*\}$'.freeze # map or object
+
     private
 
     def add_template_variables_group(tab, position, terraform_template)
@@ -102,9 +105,6 @@ class Dialog
         :read_only      => read_only
       )
     end
-
-    JSONSTR_LIST_REGEX = '^\[[\W\w]*\]$'.freeze   # list of strings or objects
-    JSONSTR_OBJECT_REGEX = '^\{[\W\w]*\}$'.freeze # map or object
 
     def add_json_variable_field(key, value, group, position, label, description, required, read_only, is_list: false)
       value = JSON.pretty_generate(value) if [Hash, Array].include?(value.class)

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
@@ -158,12 +158,14 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
     nil
   end
 
+  # Returns key/value(type constraints object, from Terraform Runner) pair.
+  # @return [Hash]
   def input_vars_type_constraints
     require 'json'
     payload = JSON.parse(template.payload)
-    payload['input_vars'] || []
+    (payload['input_vars'] || []).index_by { |v| v['name'] }
   rescue => error
     _log.error("Failure in parsing payload for template/#{template.id}, caused by #{error.message}")
-    []
+    {}
   end
 end

--- a/lib/terraform/runner.rb
+++ b/lib/terraform/runner.rb
@@ -19,20 +19,24 @@ module Terraform
       #
       # @param template_path [String] (required) path to the terraform template directory.
       # @param input_vars    [Hash]   (optional) key/value pairs as input variables for the terraform-runner run job.
+      # @param input_vars_type_constraints
+      #                      [Array]  (optional) array of type constraints objects, from Terraform Runner.
       # @param tags          [Hash]   (optional) key/value pairs tags for terraform-runner Provisioned resources.
       # @param credentials   [Array]  (optional) List of Authentication objects for the terraform run job.
       # @param env_vars      [Hash]   (optional) key/value pairs used as environment variables, for terraform-runner run job.
       #
       # @return [Terraform::Runner::ResponseAsync] Response object of terraform-runner api call
-      def create_stack(template_path, input_vars: {}, tags: nil, credentials: [], env_vars: {})
+      def create_stack(template_path, input_vars: {}, input_vars_type_constraints: [], tags: nil, credentials: [], env_vars: {})
         _log.debug("Run_aysnc/create_stack for template: #{template_path}")
         if template_path.present?
+          input_params = ApiParams.to_normalized_cam_parameters(input_vars, input_vars_type_constraints)
+
           response = create_stack_job(
             template_path,
-            :input_vars  => input_vars,
-            :tags        => tags,
-            :credentials => credentials,
-            :env_vars    => env_vars
+            :input_params => input_params,
+            :tags         => tags,
+            :credentials  => credentials,
+            :env_vars     => env_vars
           )
           Terraform::Runner::ResponseAsync.new(response.stack_id)
         else
@@ -45,19 +49,22 @@ module Terraform
       # @param stack_id      [String] (optional) required, if running ResourceAction::RETIREMENT action, used by Terraform-Runner stack_delete job.
       # @param template_path [String] (required) path to the terraform template directory.
       # @param input_vars    [Hash]   (optional) key/value pairs as input variables for the terraform-runner run job.
+      # @param input_vars_type_constraints
+      #                      [Array]  (optional) array of type constraints objects, from Terraform Runner.
       # @param credentials   [Array]  (optional) List of Authentication objects for the terraform run job.
       # @param env_vars      [Hash]   (optional) key/value pairs used as environment variables, for terraform-runner run job.
       #
       # @return [Terraform::Runner::ResponseAsync] Response object of terraform-runner api call
-      def delete_stack(stack_id, template_path, input_vars: {}, credentials: [], env_vars: {})
+      def delete_stack(stack_id, template_path, input_vars: {}, input_vars_type_constraints: [], credentials: [], env_vars: {})
         if stack_id.present? && template_path.present?
           _log.debug("Run_aysnc/delete_stack('#{stack_id}') for template: #{template_path}")
+          input_params = ApiParams.to_normalized_cam_parameters(input_vars, input_vars_type_constraints)
           response = delete_stack_job(
             stack_id,
             template_path,
-            :input_vars  => input_vars,
-            :credentials => credentials,
-            :env_vars    => env_vars
+            :input_params => input_params,
+            :credentials  => credentials,
+            :env_vars     => env_vars
           )
           Terraform::Runner::ResponseAsync.new(response.stack_id)
         else
@@ -153,7 +160,7 @@ module Terraform
       # Create TerraformRunner Stack Job
       def create_stack_job(
         template_path,
-        input_vars: {},
+        input_params: [],
         tags: nil,
         credentials: [],
         env_vars: {},
@@ -169,7 +176,7 @@ module Terraform
           :name            => name,
           :tenantId        => tenant_id,
           :templateZipFile => encoded_zip_file,
-          :parameters      => ApiParams.to_cam_parameters(input_vars)
+          :parameters      => input_params,
         }
 
         http_response = terraform_runner_client.post(
@@ -185,7 +192,7 @@ module Terraform
       def delete_stack_job(
         stack_id,
         template_path,
-        input_vars: {},
+        input_params: [],
         credentials: [],
         env_vars: {}
       )
@@ -200,7 +207,7 @@ module Terraform
           :name            => name,
           :tenantId        => tenant_id,
           :templateZipFile => encoded_zip_file,
-          :parameters      => ApiParams.to_cam_parameters(input_vars)
+          :parameters      => input_params,
         }
 
         http_response = terraform_runner_client.post(

--- a/lib/terraform/runner.rb
+++ b/lib/terraform/runner.rb
@@ -20,7 +20,7 @@ module Terraform
       # @param template_path [String] (required) path to the terraform template directory.
       # @param input_vars    [Hash]   (optional) key/value pairs as input variables for the terraform-runner run job.
       # @param input_vars_type_constraints
-      #                      [Array]  (optional) array of type constraints objects, from Terraform Runner.
+      #                      [Hash]   (optional) key/value(type constraints object, from Terraform Runner) pair.
       # @param tags          [Hash]   (optional) key/value pairs tags for terraform-runner Provisioned resources.
       # @param credentials   [Array]  (optional) List of Authentication objects for the terraform run job.
       # @param env_vars      [Hash]   (optional) key/value pairs used as environment variables, for terraform-runner run job.
@@ -50,7 +50,7 @@ module Terraform
       # @param template_path [String] (required) path to the terraform template directory.
       # @param input_vars    [Hash]   (optional) key/value pairs as input variables for the terraform-runner run job.
       # @param input_vars_type_constraints
-      #                      [Array]  (optional) array of type constraints objects, from Terraform Runner.
+      #                      [Hash]   (optional) key/value(type constraints object, from Terraform Runner) pair.
       # @param credentials   [Array]  (optional) List of Authentication objects for the terraform run job.
       # @param env_vars      [Hash]   (optional) key/value pairs used as environment variables, for terraform-runner run job.
       #

--- a/lib/terraform/runner/api_params.rb
+++ b/lib/terraform/runner/api_params.rb
@@ -81,7 +81,7 @@ module Terraform
           else
             # string or number(string)
             # (number as string, is implicitly converted by terraform, so no conversion is requried here)
-            if value.blank? && is_required == true
+            if value.blank? && is_required
               raise "The variable '#{key}', cannot be empty"
             end
           end
@@ -105,7 +105,7 @@ module Terraform
         end
 
         if value.nil?
-          if is_required == true
+          if is_required
             raise "The variable '#{key}' does not have valid #{expected_type.name} value"
           end
         elsif !value.kind_of?(expected_type)

--- a/lib/terraform/runner/api_params.rb
+++ b/lib/terraform/runner/api_params.rb
@@ -56,13 +56,15 @@ module Terraform
         require 'json'
 
         input_vars.map do |k, v|
-          type_constr = type_constraints.find { |e| e[:name] == k.to_s }
+          type_constr = type_constraints.find { |e| e['name'] == k.to_s }
 
           secured = false
           if !type_constr.nil?
-            secured = TRUE_VALUES.include?(type_constr[:secured])
+            e_secured, e_type = type_constr.values_at('secured', 'type')
 
-            case type_constr[:type]
+            secured = TRUE_VALUES.include?(e_secured)
+
+            case e_type
             when "boolean"
               v = TRUE_VALUES.include?(v)
 

--- a/lib/terraform/runner/api_params.rb
+++ b/lib/terraform/runner/api_params.rb
@@ -21,7 +21,7 @@ module Terraform
         param_list
       end
 
-      # convert to format required by terraform-runner api
+      # Convert to format required by terraform-runner api
       def self.to_cam_param(param_name, param_value, is_secured: false)
         {
           'name'    => param_name,
@@ -34,12 +34,67 @@ module Terraform
       #
       # @param vars [Hash] Hash with key/value pairs that will be passed as input variables to the
       #        terraform-runner run
+      #
       # @return [Array] Array of {:name,:value}
       def self.to_cam_parameters(vars)
         return [] if vars.nil?
 
         vars.map do |key, value|
           to_cam_param(key, value)
+        end
+      end
+
+      require 'set'
+      TRUE_VALUES = ['T', 't', true, 'true', 'True', 'TRUE'].to_set
+
+      # Normalize variables values, from ManageIQ values to Terraform Runner supported values
+      # @param input_vars       [Hash]  key/value pairs as input variables for the terraform-runner run job.
+      # @param type_constraints [Array] array of type constraints objects, from Terraform Runner
+      #
+      # @return [Array] Array of param objects [{:name,:value}]
+      def self.to_normalized_cam_parameters(input_vars, type_constraints)
+        require 'json'
+
+        input_vars.map do |k, v|
+          type_constr = type_constraints.find { |e| e[:name] == k.to_s }
+
+          secured = false
+          if !type_constr.nil?
+            secured = TRUE_VALUES.include?(type_constr[:secured])
+
+            case type_constr[:type]
+            when "boolean"
+              v = TRUE_VALUES.include?(v)
+
+            when "map"
+              if v.kind_of?(String)
+                begin
+                  v = JSON.parse(v)
+                rescue JSON::ParserError
+                  raise "The variable '#{k}' does not have valid hashmap value"
+                end
+              end
+
+              if !v.kind_of?(Hash)
+                raise "The variable '#{k}' does not have valid hashmap value"
+              end
+
+            when "list"
+              if v.kind_of?(String)
+                begin
+                  v = JSON.parse(v)
+                rescue JSON::ParserError
+                  raise "The variable '#{k}' does not have valid array value"
+                end
+              end
+
+              if !v.kind_of?(Array)
+                raise "The variable '#{k}' does not have valid array value"
+              end
+            end
+          end
+
+          to_cam_param(k, v, :is_secured => secured)
         end
       end
     end

--- a/lib/terraform/runner/api_params.rb
+++ b/lib/terraform/runner/api_params.rb
@@ -51,7 +51,7 @@ module Terraform
       # @param input_vars       [Hash]  key/value pairs as input variables for the terraform-runner run job.
       # @param type_constraints [Array] array of type constraints objects, from Terraform Runner
       #
-      # @return [Array] Array of param objects [{:name,:value}]
+      # @return [Array] Array of param objects [{name,value,secured}]
       def self.to_normalized_cam_parameters(input_vars, type_constraints)
         require 'json'
 

--- a/spec/lib/terraform/runner/api_params_spec.rb
+++ b/spec/lib/terraform/runner/api_params_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe(Terraform::Runner::ApiParams) do
         "list_of_any_types_not_nullable" => "",
       }
       expect { described_class.to_normalized_cam_parameters(input_params, type_constraints) }
-        .to raise_error(RuntimeError, "The variable 'list_of_any_types_not_nullable' does not have valid array value")
+        .to raise_error(RuntimeError, "The variable 'list_of_any_types_not_nullable' does not have valid Array value")
     end
 
     it "fails, if param of type 'list', is not a array-json-string" do
@@ -191,7 +191,7 @@ RSpec.describe(Terraform::Runner::ApiParams) do
         "list_of_strings" => "a",
       }
       expect { described_class.to_normalized_cam_parameters(input_params, type_constraints) }
-        .to raise_error(RuntimeError, "The variable 'list_of_strings' does not have valid array value")
+        .to raise_error(RuntimeError, "The variable 'list_of_strings' does not have valid Array value")
     end
 
     it "fails, if param of type 'list', is not a array" do
@@ -199,7 +199,7 @@ RSpec.describe(Terraform::Runner::ApiParams) do
         "list_of_strings" => {},
       }
       expect { described_class.to_normalized_cam_parameters(input_params, type_constraints) }
-        .to raise_error(RuntimeError, "The variable 'list_of_strings' does not have valid array value")
+        .to raise_error(RuntimeError, "The variable 'list_of_strings' does not have valid Array value")
     end
 
     it "fails, if param of type 'map', is not a hashmap-json-string" do
@@ -207,7 +207,7 @@ RSpec.describe(Terraform::Runner::ApiParams) do
         "a_object" => "\"name\": \"Sam\""
       }
       expect { described_class.to_normalized_cam_parameters(input_params, type_constraints) }
-        .to raise_error(RuntimeError, "The variable 'a_object' does not have valid hashmap value")
+        .to raise_error(RuntimeError, "The variable 'a_object' does not have valid Hash value")
     end
 
     it "fails, if param of type 'map', is not a hashmap" do
@@ -215,7 +215,7 @@ RSpec.describe(Terraform::Runner::ApiParams) do
         "a_object" => [],
       }
       expect { described_class.to_normalized_cam_parameters(input_params, type_constraints) }
-        .to raise_error(RuntimeError, "The variable 'a_object' does not have valid hashmap value")
+        .to raise_error(RuntimeError, "The variable 'a_object' does not have valid Hash value")
     end
 
     it "converts boolean value to true" do

--- a/spec/lib/terraform/runner/api_params_spec.rb
+++ b/spec/lib/terraform/runner/api_params_spec.rb
@@ -92,8 +92,8 @@ RSpec.describe(Terraform::Runner::ApiParams) do
   end
 
   describe 'Normalized manageiq vars to cam_parameters' do
-    let(:type_constraints) do
-      [
+    let(:payload) do
+      {:input_vars => [
         {"name" => "a_bool", "label" => "a_bool", "type" => "boolean", "description" => "This a boolean type, with default value", "required" => false, "secured" => false, "hidden" => false, "immutable" => false, "default" => true},
         {"name" => "a_bool_required", "label" => "a_bool_required", "type" => "boolean", "description" => "This a boolean type, value is required to provider from user", "required" => true, "secured" => false, "hidden" => false, "immutable" => false},
         {"name" => "a_number", "label" => "a_number", "type" => "number", "description" => "This a number type, with default value", "required" => false, "secured" => false, "hidden" => false, "immutable" => false, "default" => 10},
@@ -114,7 +114,12 @@ RSpec.describe(Terraform::Runner::ApiParams) do
         {"name" => "set_of_strings", "label" => "set_of_strings", "type" => "list", "description" => "The set type, holding unordered set of unique values", "required" => false, "secured" => false, "hidden" => false, "immutable" => false, "default" => ["sg-12345678", "sg-abcdefgh"]},
         {"name" => "tuple_of_all_primitive_types", "label" => "tuple_of_all_primitive_types", "type" => "list", "description" => "The tuple with three different types, which are immutable", "required" => false, "secured" => false, "hidden" => false, "immutable" => false, "default" => ["a", 15, true]},
         {"name" => "tuple_of_strings", "label" => "tuple_of_strings", "type" => "list", "description" => "The tuple of all string types, which are immutable", "required" => false, "secured" => false, "hidden" => false, "immutable" => false, "default" => ["192.168.1.1", "192.168.1.2"]}
-      ]
+      ]}
+    end
+
+    # type_constraints hash
+    let(:type_constraints) do
+      payload[:input_vars].index_by { |v| v['name'] }
     end
 
     it "converts to cam_parameters" do
@@ -143,31 +148,31 @@ RSpec.describe(Terraform::Runner::ApiParams) do
       }
 
       expect_params = [
-        {:name => "a_bool", :value => true, :secured => "false"},
-        {:name => "a_bool_required", :value => false, :secured => "false"},
-        {:name => "a_number", :value => "10", :secured => "false"},
-        {:name => "a_number_required", :value => "1", :secured => "false"},
-        {:name => "a_object", :value => {:age => 30, :email => "sam@example.com", :name => "Sam"}, :secured => "false"},
-        {:name => "a_object_with_optional_attribute", :value => {:user_id => "josh"}, :secured => "false"},
-        {:name => "a_string", :value => "World", :secured => "false"},
-        {:name => "a_string_not_nullable", :value => "a", :secured => "false"},
-        {:name => "a_string_required", :value => "b", :secured => "false"},
-        {:name => "a_string_with_sensitive_value", :value => "The Secret", :secured => "false"},
-        {:name => "list_of_any_types", :value => nil, :secured => "false"},
-        {:name => "list_of_any_types_not_nullable", :value => [1, 2, 3], :secured => "false"},
-        {:name => "list_of_object_with_nested_structures", :value => [{:name => "Production", :website => {:routing_rules => "[\n  {\n    \"Condition\" = { \"KeyPrefixEquals\": \"img/\" },\n    \"Redirect\"  = { \"ReplaceKeyPrefixWith\": \"images/\" }\n  }\n]\n"}}, {:enabled => false, :name => "archived"}], :secured => "false"},
-        {:name => "list_of_objects", :value => [{:external => 8300, :internal => 8300, :protocol => "tcp"}], :secured => "false"},
-        {:name => "list_of_strings", :value => ["micro", "large", "xlarge"], :secured => "false"},
-        {:name => "list_of_strings_required", :value => ["a", "b", "c"], :secured => "false"},
-        {:name => "map_with_string", :value => {:environment => "dev", :name => "demo"}, :secured => "false"},
-        {:name => "set_of_strings", :value => ["sg-12345678", "sg-abcdefgh"], :secured => "false"},
-        {:name => "tuple_of_all_primitive_types", :value => ["a", 15, true], :secured => "false"},
-        {:name => "tuple_of_strings", :value => ["192.168.1.1", "192.168.1.2"], :secured => "false"},
-        {:name => "extra_var", :value => "extra", :secured => "false"}
+        {"name" => "a_bool", "value" => true, "secured" => "false"},
+        {"name" => "a_bool_required", "value" => false, "secured" => "false"},
+        {"name" => "a_number", "value" => "10", "secured" => "false"},
+        {"name" => "a_number_required", "value" => "1", "secured" => "false"},
+        {"name" => "a_object", "value" => {"age" => 30, "email" => "sam@example.com", "name" => "Sam"}, "secured" => "false"},
+        {"name" => "a_object_with_optional_attribute", "value" => {"user_id" => "josh"}, "secured" => "false"},
+        {"name" => "a_string", "value" => "World", "secured" => "false"},
+        {"name" => "a_string_not_nullable", "value" => "a", "secured" => "false"},
+        {"name" => "a_string_required", "value" => "b", "secured" => "false"},
+        {"name" => "a_string_with_sensitive_value", "value" => "The Secret", "secured" => "false"},
+        {"name" => "list_of_any_types", "value" => nil, "secured" => "false"},
+        {"name" => "list_of_any_types_not_nullable", "value" => [1, 2, 3], "secured" => "false"},
+        {"name" => "list_of_object_with_nested_structures", "value" => [{"name" => "Production", "website" => {"routing_rules" => "[\n  {\n    \"Condition\" = { \"KeyPrefixEquals\": \"img/\" },\n    \"Redirect\"  = { \"ReplaceKeyPrefixWith\": \"images/\" }\n  }\n]\n"}}, {"enabled" => false, "name" => "archived"}], "secured" => "false"},
+        {"name" => "list_of_objects", "value" => [{"external" => 8300, "internal" => 8300, "protocol" => "tcp"}], "secured" => "false"},
+        {"name" => "list_of_strings", "value" => ["micro", "large", "xlarge"], "secured" => "false"},
+        {"name" => "list_of_strings_required", "value" => ["a", "b", "c"], "secured" => "false"},
+        {"name" => "map_with_string", "value" => {"environment" => "dev", "name" => "demo"}, "secured" => "false"},
+        {"name" => "set_of_strings", "value" => ["sg-12345678", "sg-abcdefgh"], "secured" => "false"},
+        {"name" => "tuple_of_all_primitive_types", "value" => ["a", 15, true], "secured" => "false"},
+        {"name" => "tuple_of_strings", "value" => ["192.168.1.1", "192.168.1.2"], "secured" => "false"},
+        {"name" => "extra_var", "value" => "extra", "secured" => "false"}
       ]
       params = described_class.to_normalized_cam_parameters(input_params, type_constraints)
 
-      expect(params.to_json).to(eq(expect_params.to_json))
+      expect(params).to(match(expect_params))
     end
 
     it "fails, if param of type 'string', is required, but is empty" do
@@ -218,6 +223,20 @@ RSpec.describe(Terraform::Runner::ApiParams) do
         .to raise_error(RuntimeError, "The variable 'a_object' does not have valid Hash value")
     end
 
+    it "does not fail, if type constraint is not available for a param" do
+      input_params = {
+        "extra-var-1" => "extra-value",
+      }
+
+      expect_params = [
+        {"name" => "extra-var-1", "value" => "extra-value", "secured" => "false"},
+      ]
+
+      params = described_class.to_normalized_cam_parameters(input_params, type_constraints)
+
+      expect(params).to(match(expect_params))
+    end
+
     it "converts boolean value to true" do
       input_params = {
         "a_bool"          => "t",
@@ -225,13 +244,13 @@ RSpec.describe(Terraform::Runner::ApiParams) do
       }
 
       expect_params = [
-        {:name => "a_bool", :value => true, :secured => "false"},
-        {:name => "a_bool_required", :value => true, :secured => "false"},
+        {"name" => "a_bool", "value" => true, "secured" => "false"},
+        {"name" => "a_bool_required", "value" => true, "secured" => "false"},
       ]
 
       params = described_class.to_normalized_cam_parameters(input_params, type_constraints)
 
-      expect(params.to_json).to(eq(expect_params.to_json))
+      expect(params).to(match(expect_params))
     end
 
     it "converts boolean value to false" do
@@ -241,13 +260,13 @@ RSpec.describe(Terraform::Runner::ApiParams) do
       }
 
       expect_params = [
-        {:name => "a_bool", :value => false, :secured => "false"},
-        {:name => "a_bool_required", :value => false, :secured => "false"},
+        {"name" => "a_bool", "value" => false, "secured" => "false"},
+        {"name" => "a_bool_required", "value" => false, "secured" => "false"},
       ]
 
       params = described_class.to_normalized_cam_parameters(input_params, type_constraints)
 
-      expect(params.to_json).to(eq(expect_params.to_json))
+      expect(params).to(match(expect_params))
     end
   end
 end

--- a/spec/lib/terraform/runner/api_params_spec.rb
+++ b/spec/lib/terraform/runner/api_params_spec.rb
@@ -94,24 +94,26 @@ RSpec.describe(Terraform::Runner::ApiParams) do
   describe 'Normalized manageiq vars to cam_parameters' do
     let(:type_constraints) do
       [
-        {"name" => "a_bool", "label" => "a_bool", "type" => "boolean", "description" => "This a boolean type, with default value", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => true},
+        {"name" => "a_bool", "label" => "a_bool", "type" => "boolean", "description" => "This a boolean type, with default value", "required" => false, "secured" => false, "hidden" => false, "immutable" => false, "default" => true},
         {"name" => "a_bool_required", "label" => "a_bool_required", "type" => "boolean", "description" => "This a boolean type, value is required to provider from user", "required" => true, "secured" => false, "hidden" => false, "immutable" => false},
-        {"name" => "a_number", "label" => "a_number", "type" => "string", "description" => "This a number type, with default value", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => 10},
-        {"name" => "a_number_required", "label" => "a_number_required", "type" => "string", "description" => "This a number type, value is required to provider from user", "required" => true, "secured" => false, "hidden" => false, "immutable" => false},
-        {"name" => "a_object", "label" => "a_object", "type" => "map", "description" => "", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => {"age" => 30, "email" => "sam@example.com", "name" => "Sam"}},
-        {"name" => "a_object_with_optional_attribute", "label" => "a_object_with_optional_attribute", "type" => "map", "description" => "", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => {"user_id"=>"josh"}},
-        {"name" => "a_string", "label" => "a_string", "type" => "string", "description" => "This a string type, with default value", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => "World"},
-        {"name" => "a_string_required", "label" => "a_string_required", "type" => "string", "description" => "This a string type, value is required to provider from user", "required" => true, "secured" => false, "hidden" => false, "immutable" => false},
-        {"name" => "a_string_with_sensitive_value", "label" => "a_string_with_sensitive_value", "type" => "string", "description" => "This a string type, with sensitive value", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => "The Secret"},
-        {"name" => "list_of_any_types", "label" => "list_of_any_types", "type" => "list", "description" => "", "required" => true, "secured" => false, "hidden" => false, "immutable" => false},
-        {"name" => "list_of_object_with_nested_structures", "label" => "list_of_object_with_nested_structures", "type" => "list", "description" => "", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => [{"name" => "Production", "website" => {"routing_rules"=>"[\n  {\n    \"Condition\" = { \"KeyPrefixEquals\": \"img/\" },\n    \"Redirect\"  = { \"ReplaceKeyPrefixWith\": \"images/\" }\n  }\n]\n"}}, {"enabled" => false, "name" => "archived"}]},
-        {"name" => "list_of_objects", "label" => "list_of_objects", "type" => "list", "description" => "", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => [{"external" => 8300, "internal" => 8300, "protocol" => "tcp"}]},
-        {"name" => "list_of_strings", "label" => "list_of_strings", "type" => "list", "description" => "", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => ["micro", "large", "xlarge"]},
+        {"name" => "a_number", "label" => "a_number", "type" => "number", "description" => "This a number type, with default value", "required" => false, "secured" => false, "hidden" => false, "immutable" => false, "default" => 10},
+        {"name" => "a_number_required", "label" => "a_number_required", "type" => "number", "description" => "This a number type, value is required to provider from user", "required" => true, "secured" => false, "hidden" => false, "immutable" => false},
+        {"name" => "a_object", "label" => "a_object", "type" => "map", "description" => "", "required" => false, "secured" => false, "hidden" => false, "immutable" => false, "default" => {"age" => 30, "email" => "sam@example.com", "name" => "Sam"}},
+        {"name" => "a_object_with_optional_attribute", "label" => "a_object_with_optional_attribute", "type" => "map", "description" => "", "required" => false, "secured" => false, "hidden" => false, "immutable" => false, "default" => {"user_id" => "josh"}},
+        {"name" => "a_string", "label" => "a_string", "type" => "string", "description" => "This a string type, with default value", "required" => false, "secured" => false, "hidden" => false, "immutable" => false, "default" => "World"},
+        {"name" => "a_string_not_nullable", "label" => "a_string_not_nullable", "type" => "string", "description" => "This a string type, cannot have null value, value is required", "required" => true, "secured" => false, "hidden" => false, "immutable" => false},
+        {"name" => "a_string_required", "label" => "a_string_required", "type" => "string", "description" => "This a string type, value is required, though can have null value", "required" => true, "secured" => false, "hidden" => false, "immutable" => false},
+        {"name" => "a_string_with_sensitive_value", "label" => "a_string_with_sensitive_value", "type" => "string", "description" => "This a string type, with sensitive value", "required" => false, "secured" => false, "hidden" => false, "immutable" => false, "default" => "The Secret"},
+        {"name" => "list_of_any_types", "label" => "list_of_any_types", "type" => "list", "description" => "This a list type, value is not required, can have null value", "required" => false, "secured" => false, "hidden" => false, "immutable" => false},
+        {"name" => "list_of_any_types_not_nullable", "label" => "list_of_any_types_not_nullable", "type" => "list", "description" => "This a list type, cannot null value, value is required,", "required" => true, "secured" => false, "hidden" => false, "immutable" => false},
+        {"name" => "list_of_object_with_nested_structures", "label" => "list_of_object_with_nested_structures", "type" => "list", "description" => "", "required" => false, "secured" => false, "hidden" => false, "immutable" => false, "default" => [{"name" => "Production", "website" => {"routing_rules" => "[\n  {\n    \"Condition\" = { \"KeyPrefixEquals\": \"img/\" },\n    \"Redirect\"  = { \"ReplaceKeyPrefixWith\": \"images/\" }\n  }\n]\n"}}, {:enabled => false, :name => "archived"}]},
+        {"name" => "list_of_objects", "label" => "list_of_objects", "type" => "list", "description" => "", "required" => false, "secured" => false, "hidden" => false, "immutable" => false, "default" => [{"external" => 8300, "internal" => 8300, "protocol" => "tcp"}]},
+        {"name" => "list_of_strings", "label" => "list_of_strings", "type" => "list", "description" => "", "required" => false, "secured" => false, "hidden" => false, "immutable" => false, "default" => ["micro", "large", "xlarge"]},
         {"name" => "list_of_strings_required", "label" => "list_of_strings_required", "type" => "list", "description" => "This a boolean type, with default value", "required" => true, "secured" => false, "hidden" => false, "immutable" => false},
-        {"name" => "map_with_string", "label" => "map_with_string", "type" => "map", "description" => "", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => {"environment" => "dev", "name" => "demo"}},
-        {"name" => "set_of_strings", "label" => "set_of_strings", "type" => "list", "description" => "The set type, holding unordered set of unique values", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => ["sg-12345678", "sg-abcdefgh"]},
-        {"name" => "tuple_of_all_primitive_types", "label" => "tuple_of_all_primitive_types", "type" => "list", "description" => "The tuple with three different types, which are immutable", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => ["a", 15, true]},
-        {"name" => "tuple_of_strings", "label" => "tuple_of_strings", "type" => "list", "description" => "The tuple of all string types, which are immutable", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => ["192.168.1.1", "192.168.1.2"]}
+        {"name" => "map_with_string", "label" => "map_with_string", "type" => "map", "description" => "", "required" => false, "secured" => false, "hidden" => false, "immutable" => false, "default" => {"environment" => "dev", "name" => "demo"}},
+        {"name" => "set_of_strings", "label" => "set_of_strings", "type" => "list", "description" => "The set type, holding unordered set of unique values", "required" => false, "secured" => false, "hidden" => false, "immutable" => false, "default" => ["sg-12345678", "sg-abcdefgh"]},
+        {"name" => "tuple_of_all_primitive_types", "label" => "tuple_of_all_primitive_types", "type" => "list", "description" => "The tuple with three different types, which are immutable", "required" => false, "secured" => false, "hidden" => false, "immutable" => false, "default" => ["a", 15, true]},
+        {"name" => "tuple_of_strings", "label" => "tuple_of_strings", "type" => "list", "description" => "The tuple of all string types, which are immutable", "required" => false, "secured" => false, "hidden" => false, "immutable" => false, "default" => ["192.168.1.1", "192.168.1.2"]}
       ]
     end
 
@@ -124,9 +126,11 @@ RSpec.describe(Terraform::Runner::ApiParams) do
         "a_object"                              => "{\n  \"age\": 30,\n  \"email\": \"sam@example.com\",\n  \"name\": \"Sam\"\n}",
         "a_object_with_optional_attribute"      => "{\n  \"user_id\": \"josh\"\n}",
         "a_string"                              => "World",
-        "a_string_required"                     => "a",
+        "a_string_not_nullable"                 => "a",
+        "a_string_required"                     => "b",
         "a_string_with_sensitive_value"         => "The Secret",
-        "list_of_any_types"                     => "[1, 2, 3]",
+        "list_of_any_types"                     => "",
+        "list_of_any_types_not_nullable"        => "[1, 2, 3]",
         "list_of_object_with_nested_structures" => "[\n  {\n    \"name\": \"Production\",\n    \"website\": {\n      \"routing_rules\": \"[\\n  {\\n    \\\"Condition\\\" = { \\\"KeyPrefixEquals\\\": \\\"img/\\\" },\\n    \\\"Redirect\\\"  = { \\\"ReplaceKeyPrefixWith\\\": \\\"images/\\\" }\\n  }\\n]\\n\"\n    }\n  },\n  {\n    \"enabled\": false,\n    \"name\": \"archived\"\n  }\n]",
         "list_of_objects"                       => "[\n  {\n    \"external\": 8300,\n    \"internal\": 8300,\n    \"protocol\": \"tcp\"\n  }\n]",
         "list_of_strings"                       => "[\n  \"micro\",\n  \"large\",\n  \"xlarge\"\n]",
@@ -146,9 +150,11 @@ RSpec.describe(Terraform::Runner::ApiParams) do
         {:name => "a_object", :value => {:age => 30, :email => "sam@example.com", :name => "Sam"}, :secured => "false"},
         {:name => "a_object_with_optional_attribute", :value => {:user_id => "josh"}, :secured => "false"},
         {:name => "a_string", :value => "World", :secured => "false"},
-        {:name => "a_string_required", :value => "a", :secured => "false"},
+        {:name => "a_string_not_nullable", :value => "a", :secured => "false"},
+        {:name => "a_string_required", :value => "b", :secured => "false"},
         {:name => "a_string_with_sensitive_value", :value => "The Secret", :secured => "false"},
-        {:name => "list_of_any_types", :value => [1, 2, 3], :secured => "false"},
+        {:name => "list_of_any_types", :value => nil, :secured => "false"},
+        {:name => "list_of_any_types_not_nullable", :value => [1, 2, 3], :secured => "false"},
         {:name => "list_of_object_with_nested_structures", :value => [{:name => "Production", :website => {:routing_rules => "[\n  {\n    \"Condition\" = { \"KeyPrefixEquals\": \"img/\" },\n    \"Redirect\"  = { \"ReplaceKeyPrefixWith\": \"images/\" }\n  }\n]\n"}}, {:enabled => false, :name => "archived"}], :secured => "false"},
         {:name => "list_of_objects", :value => [{:external => 8300, :internal => 8300, :protocol => "tcp"}], :secured => "false"},
         {:name => "list_of_strings", :value => ["micro", "large", "xlarge"], :secured => "false"},
@@ -162,6 +168,22 @@ RSpec.describe(Terraform::Runner::ApiParams) do
       params = described_class.to_normalized_cam_parameters(input_params, type_constraints)
 
       expect(params.to_json).to(eq(expect_params.to_json))
+    end
+
+    it "fails, if param of type 'string', is required, but is empty" do
+      input_params = {
+        "a_string_required" => ""
+      }
+      expect { described_class.to_normalized_cam_parameters(input_params, type_constraints) }
+        .to raise_error(RuntimeError, "The variable 'a_string_required', cannot be empty")
+    end
+
+    it "fails, if param of type 'list', is required, but is empty" do
+      input_params = {
+        "list_of_any_types_not_nullable" => "",
+      }
+      expect { described_class.to_normalized_cam_parameters(input_params, type_constraints) }
+        .to raise_error(RuntimeError, "The variable 'list_of_any_types_not_nullable' does not have valid array value")
     end
 
     it "fails, if param of type 'list', is not a array-json-string" do

--- a/spec/lib/terraform/runner/api_params_spec.rb
+++ b/spec/lib/terraform/runner/api_params_spec.rb
@@ -90,4 +90,82 @@ RSpec.describe(Terraform::Runner::ApiParams) do
             ]
           ))
   end
+
+  describe 'Normalized manageiq vars to cam_parameters' do
+    let(:type_constraints) do
+      [
+        {:name => "a_bool", :label => "a_bool", :type => "boolean", :description => "This a boolean type, with default value", :required => true, :secured => false, :hidden => false, :immutable => false, :default => true},
+        {:name => "a_bool_required", :label => "a_bool_required", :type => "boolean", :description => "This a boolean type, value is required to provider from user", :required => true, :secured => false, :hidden => false, :immutable => false},
+        {:name => "a_number", :label => "a_number", :type => "number", :description => "This a number type, with default value", :required => true, :secured => false, :hidden => false, :immutable => false, :default => 10},
+        {:name => "a_number_required", :label => "a_number_required", :type => "number", :description => "This a number type, value is required to provider from user", :required => true, :secured => false, :hidden => false, :immutable => false},
+        {:name => "a_object", :label => "a_object", :type => "map", :description => "", :required => true, :secured => false, :hidden => false, :immutable => false, :default => {:age => 30, :email => "sam@example.com", :name => "Sam"}},
+        {:name => "a_object_with_optional_attribute", :label => "a_object_with_optional_attribute", :type => "map", :description => "", :required => true, :secured => false, :hidden => false, :immutable => false, :default => {:user_id => "josh"}},
+        {:name => "a_string", :label => "a_string", :type => "string", :description => "This a string type, with default value", :required => true, :secured => false, :hidden => false, :immutable => false, :default => "World"},
+        {:name => "a_string_required", :label => "a_string_required", :type => "string", :description => "This a string type, value is required to provider from user", :required => true, :secured => false, :hidden => false, :immutable => false},
+        {:name => "a_string_with_sensitive_value", :label => "a_string_with_sensitive_value", :type => "string", :description => "This a string type, with sensitive value", :required => true, :secured => false, :hidden => false, :immutable => false, :default => "The Secret"},
+        {:name => "list_of_any_types", :label => "list_of_any_types", :type => "list", :description => "", :required => true, :secured => false, :hidden => false, :immutable => false},
+        {:name => "list_of_object_with_nested_structures", :label => "list_of_object_with_nested_structures", :type => "list", :description => "", :required => true, :secured => false, :hidden => false, :immutable => false, :default => [{:name => "Production", :website => {:routing_rules => "[\n  {\n    \"Condition\" = { \"KeyPrefixEquals\": \"img/\" },\n    \"Redirect\"  = { \"ReplaceKeyPrefixWith\": \"images/\" }\n  }\n]\n"}}, {:enabled => false, :name => "archived"}]},
+        {:name => "list_of_objects", :label => "list_of_objects", :type => "list", :description => "", :required => true, :secured => false, :hidden => false, :immutable => false, :default => [{:external => 8300, :internal => 8300, :protocol => "tcp"}]},
+        {:name => "list_of_strings", :label => "list_of_strings", :type => "list", :description => "", :required => true, :secured => false, :hidden => false, :immutable => false, :default => ["micro", "large", "xlarge"]}
+      ]
+    end
+
+    it "converts to cam_parameters" do
+      input_params = {
+        :a_bool          => "T",
+        :a_bool_required => "",
+        :a_number        => "1",
+        :a_object        => "{\"age\": 30, \"email\": \"sam@example.com\", \"name\": \"Sam\"}",
+        :list_of_objects => "[{\"external\": 8300, \"internal\": 8300, \"protocol\": \"tcp\"}]",
+        :list_of_strings => "[\"a\",\"b\",\"c\"]",
+        :extra_var       => "z"
+      }
+
+      expect_params = [
+        {"name" => "a_bool", "value" => true, "secured" => "false"},
+        {"name" => "a_bool_required", "value" => false, "secured" => "false"},
+        {"name" => "a_number", "value" => "1", "secured" => "false"},
+        {"name" => "a_object", "value" => {"age" => 30, "email" => "sam@example.com", "name" => "Sam"}, "secured" => "false"},
+        {"name" => "list_of_objects", "value" => [{"external" => 8300, "internal" => 8300, "protocol" => "tcp"}], "secured" => "false"},
+        {"name" => "list_of_strings", "value" => ["a", "b", "c"], "secured" => "false"},
+        {"name" => "extra_var", "value" => "z", "secured" => "false"}
+      ]
+
+      params = described_class.to_normalized_cam_parameters(input_params, type_constraints)
+
+      expect(params.to_json).to(eq(expect_params.to_json))
+    end
+
+    it "fails, if param of type 'list', is not a array-json-string" do
+      input_params = {
+        :list_of_strings => "a",
+      }
+      expect { described_class.to_normalized_cam_parameters(input_params, type_constraints) }
+        .to raise_error(RuntimeError, "The variable 'list_of_strings' does not have valid array value")
+    end
+
+    it "fails, if param of type 'list', is not a array" do
+      input_params = {
+        :list_of_strings => {},
+      }
+      expect { described_class.to_normalized_cam_parameters(input_params, type_constraints) }
+        .to raise_error(RuntimeError, "The variable 'list_of_strings' does not have valid array value")
+    end
+
+    it "fails, if param of type 'map', is not a hashmap-json-string" do
+      input_params = {
+        :a_object => "\"name\": \"Sam\""
+      }
+      expect { described_class.to_normalized_cam_parameters(input_params, type_constraints) }
+        .to raise_error(RuntimeError, "The variable 'a_object' does not have valid hashmap value")
+    end
+
+    it "fails, if param of type 'map', is not a hashmap" do
+      input_params = {
+        :a_object => [],
+      }
+      expect { described_class.to_normalized_cam_parameters(input_params, type_constraints) }
+        .to raise_error(RuntimeError, "The variable 'a_object' does not have valid hashmap value")
+    end
+  end
 end

--- a/spec/lib/terraform/runner/api_params_spec.rb
+++ b/spec/lib/terraform/runner/api_params_spec.rb
@@ -94,43 +94,71 @@ RSpec.describe(Terraform::Runner::ApiParams) do
   describe 'Normalized manageiq vars to cam_parameters' do
     let(:type_constraints) do
       [
-        {:name => "a_bool", :label => "a_bool", :type => "boolean", :description => "This a boolean type, with default value", :required => true, :secured => false, :hidden => false, :immutable => false, :default => true},
-        {:name => "a_bool_required", :label => "a_bool_required", :type => "boolean", :description => "This a boolean type, value is required to provider from user", :required => true, :secured => false, :hidden => false, :immutable => false},
-        {:name => "a_number", :label => "a_number", :type => "number", :description => "This a number type, with default value", :required => true, :secured => false, :hidden => false, :immutable => false, :default => 10},
-        {:name => "a_number_required", :label => "a_number_required", :type => "number", :description => "This a number type, value is required to provider from user", :required => true, :secured => false, :hidden => false, :immutable => false},
-        {:name => "a_object", :label => "a_object", :type => "map", :description => "", :required => true, :secured => false, :hidden => false, :immutable => false, :default => {:age => 30, :email => "sam@example.com", :name => "Sam"}},
-        {:name => "a_object_with_optional_attribute", :label => "a_object_with_optional_attribute", :type => "map", :description => "", :required => true, :secured => false, :hidden => false, :immutable => false, :default => {:user_id => "josh"}},
-        {:name => "a_string", :label => "a_string", :type => "string", :description => "This a string type, with default value", :required => true, :secured => false, :hidden => false, :immutable => false, :default => "World"},
-        {:name => "a_string_required", :label => "a_string_required", :type => "string", :description => "This a string type, value is required to provider from user", :required => true, :secured => false, :hidden => false, :immutable => false},
-        {:name => "a_string_with_sensitive_value", :label => "a_string_with_sensitive_value", :type => "string", :description => "This a string type, with sensitive value", :required => true, :secured => false, :hidden => false, :immutable => false, :default => "The Secret"},
-        {:name => "list_of_any_types", :label => "list_of_any_types", :type => "list", :description => "", :required => true, :secured => false, :hidden => false, :immutable => false},
-        {:name => "list_of_object_with_nested_structures", :label => "list_of_object_with_nested_structures", :type => "list", :description => "", :required => true, :secured => false, :hidden => false, :immutable => false, :default => [{:name => "Production", :website => {:routing_rules => "[\n  {\n    \"Condition\" = { \"KeyPrefixEquals\": \"img/\" },\n    \"Redirect\"  = { \"ReplaceKeyPrefixWith\": \"images/\" }\n  }\n]\n"}}, {:enabled => false, :name => "archived"}]},
-        {:name => "list_of_objects", :label => "list_of_objects", :type => "list", :description => "", :required => true, :secured => false, :hidden => false, :immutable => false, :default => [{:external => 8300, :internal => 8300, :protocol => "tcp"}]},
-        {:name => "list_of_strings", :label => "list_of_strings", :type => "list", :description => "", :required => true, :secured => false, :hidden => false, :immutable => false, :default => ["micro", "large", "xlarge"]}
+        {"name" => "a_bool", "label" => "a_bool", "type" => "boolean", "description" => "This a boolean type, with default value", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => true},
+        {"name" => "a_bool_required", "label" => "a_bool_required", "type" => "boolean", "description" => "This a boolean type, value is required to provider from user", "required" => true, "secured" => false, "hidden" => false, "immutable" => false},
+        {"name" => "a_number", "label" => "a_number", "type" => "string", "description" => "This a number type, with default value", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => 10},
+        {"name" => "a_number_required", "label" => "a_number_required", "type" => "string", "description" => "This a number type, value is required to provider from user", "required" => true, "secured" => false, "hidden" => false, "immutable" => false},
+        {"name" => "a_object", "label" => "a_object", "type" => "map", "description" => "", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => {"age" => 30, "email" => "sam@example.com", "name" => "Sam"}},
+        {"name" => "a_object_with_optional_attribute", "label" => "a_object_with_optional_attribute", "type" => "map", "description" => "", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => {"user_id"=>"josh"}},
+        {"name" => "a_string", "label" => "a_string", "type" => "string", "description" => "This a string type, with default value", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => "World"},
+        {"name" => "a_string_required", "label" => "a_string_required", "type" => "string", "description" => "This a string type, value is required to provider from user", "required" => true, "secured" => false, "hidden" => false, "immutable" => false},
+        {"name" => "a_string_with_sensitive_value", "label" => "a_string_with_sensitive_value", "type" => "string", "description" => "This a string type, with sensitive value", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => "The Secret"},
+        {"name" => "list_of_any_types", "label" => "list_of_any_types", "type" => "list", "description" => "", "required" => true, "secured" => false, "hidden" => false, "immutable" => false},
+        {"name" => "list_of_object_with_nested_structures", "label" => "list_of_object_with_nested_structures", "type" => "list", "description" => "", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => [{"name" => "Production", "website" => {"routing_rules"=>"[\n  {\n    \"Condition\" = { \"KeyPrefixEquals\": \"img/\" },\n    \"Redirect\"  = { \"ReplaceKeyPrefixWith\": \"images/\" }\n  }\n]\n"}}, {"enabled" => false, "name" => "archived"}]},
+        {"name" => "list_of_objects", "label" => "list_of_objects", "type" => "list", "description" => "", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => [{"external" => 8300, "internal" => 8300, "protocol" => "tcp"}]},
+        {"name" => "list_of_strings", "label" => "list_of_strings", "type" => "list", "description" => "", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => ["micro", "large", "xlarge"]},
+        {"name" => "list_of_strings_required", "label" => "list_of_strings_required", "type" => "list", "description" => "This a boolean type, with default value", "required" => true, "secured" => false, "hidden" => false, "immutable" => false},
+        {"name" => "map_with_string", "label" => "map_with_string", "type" => "map", "description" => "", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => {"environment" => "dev", "name" => "demo"}},
+        {"name" => "set_of_strings", "label" => "set_of_strings", "type" => "list", "description" => "The set type, holding unordered set of unique values", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => ["sg-12345678", "sg-abcdefgh"]},
+        {"name" => "tuple_of_all_primitive_types", "label" => "tuple_of_all_primitive_types", "type" => "list", "description" => "The tuple with three different types, which are immutable", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => ["a", 15, true]},
+        {"name" => "tuple_of_strings", "label" => "tuple_of_strings", "type" => "list", "description" => "The tuple of all string types, which are immutable", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => ["192.168.1.1", "192.168.1.2"]}
       ]
     end
 
     it "converts to cam_parameters" do
       input_params = {
-        :a_bool          => "T",
-        :a_bool_required => "",
-        :a_number        => "1",
-        :a_object        => "{\"age\": 30, \"email\": \"sam@example.com\", \"name\": \"Sam\"}",
-        :list_of_objects => "[{\"external\": 8300, \"internal\": 8300, \"protocol\": \"tcp\"}]",
-        :list_of_strings => "[\"a\",\"b\",\"c\"]",
-        :extra_var       => "z"
+        "a_bool"                                => "t",
+        "a_bool_required"                       => "",
+        "a_number"                              => "10",
+        "a_number_required"                     => "1",
+        "a_object"                              => "{\n  \"age\": 30,\n  \"email\": \"sam@example.com\",\n  \"name\": \"Sam\"\n}",
+        "a_object_with_optional_attribute"      => "{\n  \"user_id\": \"josh\"\n}",
+        "a_string"                              => "World",
+        "a_string_required"                     => "a",
+        "a_string_with_sensitive_value"         => "The Secret",
+        "list_of_any_types"                     => "[1, 2, 3]",
+        "list_of_object_with_nested_structures" => "[\n  {\n    \"name\": \"Production\",\n    \"website\": {\n      \"routing_rules\": \"[\\n  {\\n    \\\"Condition\\\" = { \\\"KeyPrefixEquals\\\": \\\"img/\\\" },\\n    \\\"Redirect\\\"  = { \\\"ReplaceKeyPrefixWith\\\": \\\"images/\\\" }\\n  }\\n]\\n\"\n    }\n  },\n  {\n    \"enabled\": false,\n    \"name\": \"archived\"\n  }\n]",
+        "list_of_objects"                       => "[\n  {\n    \"external\": 8300,\n    \"internal\": 8300,\n    \"protocol\": \"tcp\"\n  }\n]",
+        "list_of_strings"                       => "[\n  \"micro\",\n  \"large\",\n  \"xlarge\"\n]",
+        "list_of_strings_required"              => "[\"a\",\"b\",\"c\"]",
+        "map_with_string"                       => "{\n  \"environment\": \"dev\",\n  \"name\": \"demo\"\n}",
+        "set_of_strings"                        => "[\n  \"sg-12345678\",\n  \"sg-abcdefgh\"\n]",
+        "tuple_of_all_primitive_types"          => "[\n  \"a\",\n  15,\n  true\n]",
+        "tuple_of_strings"                      => "[\n  \"192.168.1.1\",\n  \"192.168.1.2\"\n]",
+        "extra_var"                             => "extra",
       }
 
       expect_params = [
-        {"name" => "a_bool", "value" => true, "secured" => "false"},
-        {"name" => "a_bool_required", "value" => false, "secured" => "false"},
-        {"name" => "a_number", "value" => "1", "secured" => "false"},
-        {"name" => "a_object", "value" => {"age" => 30, "email" => "sam@example.com", "name" => "Sam"}, "secured" => "false"},
-        {"name" => "list_of_objects", "value" => [{"external" => 8300, "internal" => 8300, "protocol" => "tcp"}], "secured" => "false"},
-        {"name" => "list_of_strings", "value" => ["a", "b", "c"], "secured" => "false"},
-        {"name" => "extra_var", "value" => "z", "secured" => "false"}
+        {:name => "a_bool", :value => true, :secured => "false"},
+        {:name => "a_bool_required", :value => false, :secured => "false"},
+        {:name => "a_number", :value => "10", :secured => "false"},
+        {:name => "a_number_required", :value => "1", :secured => "false"},
+        {:name => "a_object", :value => {:age => 30, :email => "sam@example.com", :name => "Sam"}, :secured => "false"},
+        {:name => "a_object_with_optional_attribute", :value => {:user_id => "josh"}, :secured => "false"},
+        {:name => "a_string", :value => "World", :secured => "false"},
+        {:name => "a_string_required", :value => "a", :secured => "false"},
+        {:name => "a_string_with_sensitive_value", :value => "The Secret", :secured => "false"},
+        {:name => "list_of_any_types", :value => [1, 2, 3], :secured => "false"},
+        {:name => "list_of_object_with_nested_structures", :value => [{:name => "Production", :website => {:routing_rules => "[\n  {\n    \"Condition\" = { \"KeyPrefixEquals\": \"img/\" },\n    \"Redirect\"  = { \"ReplaceKeyPrefixWith\": \"images/\" }\n  }\n]\n"}}, {:enabled => false, :name => "archived"}], :secured => "false"},
+        {:name => "list_of_objects", :value => [{:external => 8300, :internal => 8300, :protocol => "tcp"}], :secured => "false"},
+        {:name => "list_of_strings", :value => ["micro", "large", "xlarge"], :secured => "false"},
+        {:name => "list_of_strings_required", :value => ["a", "b", "c"], :secured => "false"},
+        {:name => "map_with_string", :value => {:environment => "dev", :name => "demo"}, :secured => "false"},
+        {:name => "set_of_strings", :value => ["sg-12345678", "sg-abcdefgh"], :secured => "false"},
+        {:name => "tuple_of_all_primitive_types", :value => ["a", 15, true], :secured => "false"},
+        {:name => "tuple_of_strings", :value => ["192.168.1.1", "192.168.1.2"], :secured => "false"},
+        {:name => "extra_var", :value => "extra", :secured => "false"}
       ]
-
       params = described_class.to_normalized_cam_parameters(input_params, type_constraints)
 
       expect(params.to_json).to(eq(expect_params.to_json))
@@ -138,7 +166,7 @@ RSpec.describe(Terraform::Runner::ApiParams) do
 
     it "fails, if param of type 'list', is not a array-json-string" do
       input_params = {
-        :list_of_strings => "a",
+        "list_of_strings" => "a",
       }
       expect { described_class.to_normalized_cam_parameters(input_params, type_constraints) }
         .to raise_error(RuntimeError, "The variable 'list_of_strings' does not have valid array value")
@@ -146,7 +174,7 @@ RSpec.describe(Terraform::Runner::ApiParams) do
 
     it "fails, if param of type 'list', is not a array" do
       input_params = {
-        :list_of_strings => {},
+        "list_of_strings" => {},
       }
       expect { described_class.to_normalized_cam_parameters(input_params, type_constraints) }
         .to raise_error(RuntimeError, "The variable 'list_of_strings' does not have valid array value")
@@ -154,7 +182,7 @@ RSpec.describe(Terraform::Runner::ApiParams) do
 
     it "fails, if param of type 'map', is not a hashmap-json-string" do
       input_params = {
-        :a_object => "\"name\": \"Sam\""
+        "a_object" => "\"name\": \"Sam\""
       }
       expect { described_class.to_normalized_cam_parameters(input_params, type_constraints) }
         .to raise_error(RuntimeError, "The variable 'a_object' does not have valid hashmap value")
@@ -162,10 +190,42 @@ RSpec.describe(Terraform::Runner::ApiParams) do
 
     it "fails, if param of type 'map', is not a hashmap" do
       input_params = {
-        :a_object => [],
+        "a_object" => [],
       }
       expect { described_class.to_normalized_cam_parameters(input_params, type_constraints) }
         .to raise_error(RuntimeError, "The variable 'a_object' does not have valid hashmap value")
+    end
+
+    it "converts boolean value to true" do
+      input_params = {
+        "a_bool"          => "t",
+        "a_bool_required" => true,
+      }
+
+      expect_params = [
+        {:name => "a_bool", :value => true, :secured => "false"},
+        {:name => "a_bool_required", :value => true, :secured => "false"},
+      ]
+
+      params = described_class.to_normalized_cam_parameters(input_params, type_constraints)
+
+      expect(params.to_json).to(eq(expect_params.to_json))
+    end
+
+    it "converts boolean value to false" do
+      input_params = {
+        "a_bool"          => "f",
+        "a_bool_required" => "",
+      }
+
+      expect_params = [
+        {:name => "a_bool", :value => false, :secured => "false"},
+        {:name => "a_bool_required", :value => false, :secured => "false"},
+      ]
+
+      params = described_class.to_normalized_cam_parameters(input_params, type_constraints)
+
+      expect(params.to_json).to(eq(expect_params.to_json))
     end
   end
 end

--- a/spec/lib/terraform/runner_spec.rb
+++ b/spec/lib/terraform/runner_spec.rb
@@ -63,9 +63,9 @@ RSpec.describe(Terraform::Runner) do
       let(:input_vars) { {'name' => 'New World'} }
 
       let(:input_vars_type_constraints) do
-        [
-          {"name" => "name", "label" => "Name", "type" => "string", "description" => "name is required", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => "World"},
-        ]
+        {
+          "name" => {"name" => "name", "label" => "Name", "type" => "string", "description" => "name is required", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => "World"},
+        }
       end
 
       it "start running hello-world terraform template" do
@@ -235,9 +235,9 @@ RSpec.describe(Terraform::Runner) do
       let(:input_vars) { {'name' => 'New World'} }
 
       let(:input_vars_type_constraints) do
-        [
-          {"name" => "name", "label" => "Name", "type" => "string", "description" => "name is required", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => "World"},
-        ]
+        {
+          "name" => {"name" => "name", "label" => "Name", "type" => "string", "description" => "name is required", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => "World"},
+        }
       end
 
       it ".delete_stack to run retirement with hello-world terraform template stack" do

--- a/spec/lib/terraform/runner_spec.rb
+++ b/spec/lib/terraform/runner_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe(Terraform::Runner) do
   end
 
   context '.create_stack for hello-world' do
-    describe '.create_stack with input_var' do
+    describe '.create_stack with input_vars' do
       create_stub = nil
       retrieve_stub = nil
 
@@ -62,8 +62,14 @@ RSpec.describe(Terraform::Runner) do
 
       let(:input_vars) { {'name' => 'New World'} }
 
+      let(:input_vars_type_constraints) do
+        [
+          {"name" => "name", "label" => "Name", "type" => "string", "description" => "name is required", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => "World"},
+        ]
+      end
+
       it "start running hello-world terraform template" do
-        async_response = Terraform::Runner.create_stack(File.join(__dir__, "runner/data/hello-world"), :input_vars => input_vars)
+        async_response = Terraform::Runner.create_stack(File.join(__dir__, "runner/data/hello-world"), :input_vars => input_vars, :input_vars_type_constraints => input_vars_type_constraints)
         expect(create_stub).to(have_been_requested.times(1))
 
         response = async_response.response
@@ -78,7 +84,7 @@ RSpec.describe(Terraform::Runner) do
       end
 
       it "handles trailing '/' in template path" do
-        async_response = Terraform::Runner.create_stack(File.join(__dir__, "runner/data/hello-world/"), :input_vars => input_vars)
+        async_response = Terraform::Runner.create_stack(File.join(__dir__, "runner/data/hello-world/"), :input_vars => input_vars, :input_vars_type_constraints => input_vars_type_constraints)
         expect(create_stub).to(have_been_requested.times(1))
 
         response = async_response.response
@@ -228,11 +234,18 @@ RSpec.describe(Terraform::Runner) do
 
       let(:input_vars) { {'name' => 'New World'} }
 
+      let(:input_vars_type_constraints) do
+        [
+          {"name" => "name", "label" => "Name", "type" => "string", "description" => "name is required", "required" => true, "secured" => false, "hidden" => false, "immutable" => false, "default" => "World"},
+        ]
+      end
+
       it ".delete_stack to run retirement with hello-world terraform template stack" do
         async_response = Terraform::Runner.delete_stack(
           @hello_world_retrieve_delete_response['stack_id'],
           File.join(__dir__, "runner/data/hello-world"),
-          :input_vars => input_vars
+          :input_vars                  => input_vars,
+          :input_vars_type_constraints => input_vars_type_constraints
         )
         expect(delete_stub).to(have_been_requested.times(1))
 


### PR DESCRIPTION
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->
This is a enhancement to dynamic dialog field generation for terraform. 
This change provides better support for terraform input variables dialog generation, in regards terraform input variable type constraints, such as List,Map,Number,Boolean,nullable values 

* Instead of only Textbox field for input-vars with List & Map type constraint, 
   * now TextAreabox fields will be added.
   * The default JSON values are prettified in textarea fields,  for easier editing of the JSON values. 
   * Also the List & Map will have some limited validation support with fields using regex
* This also fixes earlier implementation, where for type such as List & Map, the value was sent as JSON string, 
   * now the JSON is converted to JSON object or when required to nil value, before sending to terraform-runner api's 
* Number type field a little better support with regex validation.
* Boolean type field values,
   * now Checkbox field is added 
   * user value is convert to true or false, before sending to terraform-runner api.

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->


<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
