### PR TITLE
Fix liveness & readiness probe endpoint for terraform-runner

### DIFF
--- a/app/models/opentofu_worker.rb
+++ b/app/models/opentofu_worker.rb
@@ -38,12 +38,12 @@ class OpentofuWorker < MiqWorker
   end
 
   def add_liveness_probe(container_definition)
-    container_definition[:livenessProbe] = container_definition[:livenessProbe].except(:exec).merge(:httpGet => {:path => "/api/v1/ready", :port => SERVICE_PORT, :scheme => "HTTPS"})
+    container_definition[:livenessProbe] = container_definition[:livenessProbe].except(:exec).merge(:httpGet => {:path => "/live", :port => SERVICE_PORT, :scheme => "HTTPS"})
   end
 
   def add_readiness_probe(container_definition)
     container_definition[:readinessProbe] = {
-      :httpGet             => {:path => "/api/v1/ready", :port => SERVICE_PORT, :scheme => "HTTPS"},
+      :httpGet             => {:path => "/ready", :port => SERVICE_PORT, :scheme => "HTTPS"},
       :initialDelaySeconds => 60,
       :timeoutSeconds      => 3
     }

--- a/lib/terraform/runner.rb
+++ b/lib/terraform/runner.rb
@@ -9,7 +9,7 @@ module Terraform
       def available?
         return @available if defined?(@available)
 
-        response = terraform_runner_client.get('live')
+        response = terraform_runner_client.get('ready')
         @available = response.status == 200 && JSON.parse(response.body)['status'] == 'UP'
       rescue
         @available = false

--- a/spec/lib/terraform/runner_spec.rb
+++ b/spec/lib/terraform/runner_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe(Terraform::Runner) do
 
   describe "is .available" do
     before do
-      stub_request(:get, "#{terraform_runner_url}/live")
+      stub_request(:get, "#{terraform_runner_url}/ready")
         .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
     end
 


### PR DESCRIPTION
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

The liveness_probe & readiness_probe endpoint  for opentofu-runner are in-correct in the OpentofuWorker code

https://github.com/ManageIQ/manageiq-providers-embedded_terraform/blob/master/app/models/opentofu_worker.rb#L41
https://github.com/ManageIQ/manageiq-providers-embedded_terraform/blob/master/app/models/opentofu_worker.rb#L46

Instead of `/ready`,   ~~`/api/v1/ready`~~  has been used.

So, in the logs of opentofu-runner, we see ->

```
[2025-04-11T05:38:04.667] [ERROR] auth.provider - /api/v1/ready does not have valid token 
```

because all api endpoints need valid token for authentication,
expect  `/live`, `/ready`, `/health` & `/ping`

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
