### PR TITLE
Remove redundant extra_vars, as input_vars from service dialog is used for Terraform Template

### DIFF
--- a/app/models/dialog/terraform_template_service_dialog.rb
+++ b/app/models/dialog/terraform_template_service_dialog.rb
@@ -1,24 +1,14 @@
 class Dialog
   class TerraformTemplateServiceDialog
-    # def self.create_dialog(label, terraform_template, extra_vars)
-    #   new.create_dialog(label, terraform_template, extra_vars)
-    # end
-
     def self.create_dialog(label, terraform_template)
       new.create_dialog(label, terraform_template)
     end
 
     # This dialog is to be used by a terraform template service item
-    # def create_dialog(label, terraform_template, extra_vars)
     def create_dialog(label, terraform_template)
       Dialog.new(:label => label, :buttons => "submit,cancel").tap do |dialog|
         tab = dialog.dialog_tabs.build(:display => "edit", :label => "Basic Information", :position => 0)
-        position = 0
-        add_template_variables_group(tab, position, terraform_template)
-
-        # if extra_vars.present?
-        #   add_variables_group(tab, position, extra_vars)
-        # end
+        add_template_variables_group(tab, 0, terraform_template)
 
         dialog.save!
       end
@@ -76,18 +66,6 @@ class Dialog
         end
       end
     end
-
-    # def add_variables_group(tab, position, extra_vars)
-    #   tab.dialog_groups.build(
-    #     :display  => "edit",
-    #     :label    => "Variables",
-    #     :position => position
-    #   ).tap do |dialog_group|
-    #     extra_vars.transform_values { |val| val[:default] }.each_with_index do |(key, value), index|
-    #       add_variable_field(key, value, dialog_group, index, key, key, false, false)
-    #     end
-    #   end
-    # end
 
     def add_variable_field(key, value, group, position, label, description, required, read_only)
       value = value.to_json if [Hash, Array].include?(value.class)

--- a/app/models/dialog/terraform_template_service_dialog.rb
+++ b/app/models/dialog/terraform_template_service_dialog.rb
@@ -1,27 +1,24 @@
 class Dialog
   class TerraformTemplateServiceDialog
-    def self.create_dialog(label, terraform_template, extra_vars)
-      new.create_dialog(label, terraform_template, extra_vars)
+    # def self.create_dialog(label, terraform_template, extra_vars)
+    #   new.create_dialog(label, terraform_template, extra_vars)
+    # end
+
+    def self.create_dialog(label, terraform_template)
+      new.create_dialog(label, terraform_template)
     end
 
     # This dialog is to be used by a terraform template service item
-    def create_dialog(label, terraform_template, extra_vars)
+    # def create_dialog(label, terraform_template, extra_vars)
+    def create_dialog(label, terraform_template)
       Dialog.new(:label => label, :buttons => "submit,cancel").tap do |dialog|
         tab = dialog.dialog_tabs.build(:display => "edit", :label => "Basic Information", :position => 0)
         position = 0
-        if terraform_template.present? && add_template_variables_group(tab, position, terraform_template)
-          position += 1
-        end
-        if extra_vars.present?
-          add_variables_group(tab, position, extra_vars)
-          position += 1
-        end
+        add_template_variables_group(tab, position, terraform_template)
 
-        if position == 0
-          # if not template input vars & no extra_vars,
-          # then add single variable text box as place-holder
-          add_variables_group(tab, position, {:name => {:default => label}})
-        end
+        # if extra_vars.present?
+        #   add_variables_group(tab, position, extra_vars)
+        # end
 
         dialog.save!
       end
@@ -80,17 +77,17 @@ class Dialog
       end
     end
 
-    def add_variables_group(tab, position, extra_vars)
-      tab.dialog_groups.build(
-        :display  => "edit",
-        :label    => "Variables",
-        :position => position
-      ).tap do |dialog_group|
-        extra_vars.transform_values { |val| val[:default] }.each_with_index do |(key, value), index|
-          add_variable_field(key, value, dialog_group, index, key, key, false, false)
-        end
-      end
-    end
+    # def add_variables_group(tab, position, extra_vars)
+    #   tab.dialog_groups.build(
+    #     :display  => "edit",
+    #     :label    => "Variables",
+    #     :position => position
+    #   ).tap do |dialog_group|
+    #     extra_vars.transform_values { |val| val[:default] }.each_with_index do |(key, value), index|
+    #       add_variable_field(key, value, dialog_group, index, key, key, false, false)
+    #     end
+    #   end
+    # end
 
     def add_variable_field(key, value, group, position, label, description, required, read_only)
       value = value.to_json if [Hash, Array].include?(value.class)

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
@@ -178,7 +178,7 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
   end
 
   def input_vars
-    options.dig(:input_vars, :input_vars) || {}
+    ServiceTerraformTemplate.get_input_vars_from_job_options(options)
   end
 
   def terraform_runner_action_type(resource_action)

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
@@ -178,10 +178,6 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
   end
 
   def input_vars
-    # extra_vars = options.dig(:input_vars, :extra_vars) || {}
-    # input_vars = options.dig(:input_vars, :input_vars) || {}
-    # # merge & over extra_vars with input_vars
-    # extra_vars.deep_merge!(input_vars)
     options.dig(:input_vars, :input_vars) || {}
   end
 

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
@@ -178,10 +178,11 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
   end
 
   def input_vars
-    extra_vars = options.dig(:input_vars, :extra_vars) || {}
-    input_vars = options.dig(:input_vars, :input_vars) || {}
-    # merge & over extra_vars with input_vars
-    extra_vars.deep_merge!(input_vars)
+    # extra_vars = options.dig(:input_vars, :extra_vars) || {}
+    # input_vars = options.dig(:input_vars, :input_vars) || {}
+    # # merge & over extra_vars with input_vars
+    # extra_vars.deep_merge!(input_vars)
+    options.dig(:input_vars, :input_vars) || {}
   end
 
   def terraform_runner_action_type(resource_action)

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
@@ -178,7 +178,7 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
   end
 
   def input_vars
-    ServiceTerraformTemplate.get_input_vars_from_job_options(options)
+    options.fetch(:input_vars, {})
   end
 
   def terraform_runner_action_type(resource_action)

--- a/app/models/service_template_terraform_template.rb
+++ b/app/models/service_template_terraform_template.rb
@@ -80,7 +80,6 @@ class ServiceTemplateTerraformTemplate < ServiceTemplate
         provision_dialog_id = create_new_dialog(
           info[:new_dialog_name],
           terraform_template(:provision)
-          # info[:extra_vars]
         ).id
         dialog_hash[:provision] = {:dialog_id => provision_dialog_id}
       else
@@ -97,10 +96,6 @@ class ServiceTemplateTerraformTemplate < ServiceTemplate
   end
 
   private
-
-  # def create_new_dialog(dialog_name, terraform_template, extra_vars)
-  #   Dialog::TerraformTemplateServiceDialog.create_dialog(dialog_name, terraform_template, extra_vars)
-  # end
 
   def create_new_dialog(dialog_name, terraform_template)
     Dialog::TerraformTemplateServiceDialog.create_dialog(dialog_name, terraform_template)

--- a/app/models/service_template_terraform_template.rb
+++ b/app/models/service_template_terraform_template.rb
@@ -40,7 +40,7 @@ class ServiceTemplateTerraformTemplate < ServiceTemplate
   end
 
   private_class_method def self.validate_config_info(config_info)
-    raise _("Must provide a configuration_script_payload_id") if !config_info.key?(:provision) || config_info[:provision][:configuration_script_payload_id].nil?
+    raise _("Must provide a configuration_script_payload_id") if config_info.dig(:provision, :configuration_script_payload_id).nil?
 
     config_info[:provision][:fqname] ||= default_provisioning_entry_point(SERVICE_TYPE_ATOMIC)
 

--- a/app/models/service_template_terraform_template.rb
+++ b/app/models/service_template_terraform_template.rb
@@ -77,7 +77,11 @@ class ServiceTemplateTerraformTemplate < ServiceTemplate
     if info
       # create new dialog, if required for :provision action
       if info.key?(:new_dialog_name) && !info.key?(:dialog_id)
-        provision_dialog_id = create_new_dialog(info[:new_dialog_name], terraform_template(:provision), info[:extra_vars]).id
+        provision_dialog_id = create_new_dialog(
+          info[:new_dialog_name],
+          terraform_template(:provision)
+          # info[:extra_vars]
+        ).id
         dialog_hash[:provision] = {:dialog_id => provision_dialog_id}
       else
         provision_dialog_id = info[:dialog_id]
@@ -94,8 +98,12 @@ class ServiceTemplateTerraformTemplate < ServiceTemplate
 
   private
 
-  def create_new_dialog(dialog_name, terraform_template, extra_vars)
-    Dialog::TerraformTemplateServiceDialog.create_dialog(dialog_name, terraform_template, extra_vars)
+  # def create_new_dialog(dialog_name, terraform_template, extra_vars)
+  #   Dialog::TerraformTemplateServiceDialog.create_dialog(dialog_name, terraform_template, extra_vars)
+  # end
+
+  def create_new_dialog(dialog_name, terraform_template)
+    Dialog::TerraformTemplateServiceDialog.create_dialog(dialog_name, terraform_template)
   end
 
   def validate_update_config_info(options)

--- a/app/models/service_template_terraform_template.rb
+++ b/app/models/service_template_terraform_template.rb
@@ -39,28 +39,24 @@ class ServiceTemplateTerraformTemplate < ServiceTemplate
     super
   end
 
-  private_class_method def self.validate_config_info(info)
-    info[:provision][:fqname] ||= default_provisioning_entry_point(SERVICE_TYPE_ATOMIC) if info.key?(:provision)
+  private_class_method def self.validate_config_info(config_info)
+    raise _("Must provide a configuration_script_payload_id") if !config_info.key?(:provision) || config_info[:provision][:configuration_script_payload_id].nil?
+
+    config_info[:provision][:fqname] ||= default_provisioning_entry_point(SERVICE_TYPE_ATOMIC)
+
+    prov_info_copy = config_info[:provision].except(:fqname)
 
     # By default, for Reconfigure(terraform apply) will have same config as Provision,
     # though the input parameters values, can be changed by the user
-    info[:reconfigure] ||= retirement_or_reconfigure_default_info(info[:provision])
-    info[:reconfigure][:fqname] ||= default_reconfiguration_entry_point
+    config_info[:reconfigure] ||= prov_info_copy.deep_dup
+    config_info[:reconfigure][:fqname] ||= default_reconfiguration_entry_point
 
     # By default, for Retirement(terraform destroy) will have same config as Provision config,
     # because retirement(terraform destroy) action is run in-reverse order with same terraform template.
-    info[:retirement] ||= retirement_or_reconfigure_default_info(info[:provision])
-    info[:retirement][:fqname] ||= default_retirement_entry_point
+    config_info[:retirement] ||= prov_info_copy.deep_dup
+    config_info[:retirement][:fqname] ||= default_retirement_entry_point
 
-    raise _("Must provide a configuration_script_payload_id") if info[:provision][:configuration_script_payload_id].nil?
-
-    info
-  end
-
-  private_class_method def self.retirement_or_reconfigure_default_info(prov_info)
-    info = prov_info.deep_dup
-    info.delete(:fqname)
-    info
+    config_info
   end
 
   def terraform_template(action)

--- a/app/models/service_terraform_template.rb
+++ b/app/models/service_terraform_template.rb
@@ -53,8 +53,7 @@ class ServiceTerraformTemplate < ServiceGeneric
 
   def postprocess(action)
     $embedded_terraform_log.debug("Service(#{id}).postprocess(#{action}) starts")
-    case action
-    when ResourceAction::RECONFIGURE
+    if action == ResourceAction::RECONFIGURE
       # As we have reached here, so the action was successful.
       # Now we update the Service with dialog options from Reconfiguration
       $embedded_terraform_log.info("successfully reconfiguired, save reconfigure job options, to service dialog options")

--- a/app/models/service_terraform_template.rb
+++ b/app/models/service_terraform_template.rb
@@ -114,7 +114,9 @@ class ServiceTerraformTemplate < ServiceGeneric
     [true, nil]
   end
 
-  def self.get_input_vars_from_job_options(job_options)
+  private
+
+  def get_input_vars_from_job_options(job_options)
     return {} if job_options.nil?
 
     input_vars = job_options.fetch(:input_vars, {})
@@ -129,8 +131,6 @@ class ServiceTerraformTemplate < ServiceGeneric
 
     input_vars
   end
-
-  private
 
   def job(action)
     stack(action)&.miq_task&.job
@@ -220,7 +220,7 @@ class ServiceTerraformTemplate < ServiceGeneric
 
     {
       :terraform_stack_id => action_job.options[:terraform_stack_id],
-      :input_vars         => ServiceTerraformTemplate.get_input_vars_from_job_options(action_job.options).deep_dup
+      :input_vars         => get_input_vars_from_job_options(action_job.options).deep_dup
     }
   end
 

--- a/app/models/service_terraform_template.rb
+++ b/app/models/service_terraform_template.rb
@@ -115,6 +115,22 @@ class ServiceTerraformTemplate < ServiceGeneric
     [true, nil]
   end
 
+  def self.get_input_vars_from_job_options(job_options)
+    return {} if job_options.nil?
+
+    input_vars = job_options.fetch(:input_vars, {})
+
+    # Handle backward compatibility: nested :input_vars inside :input_vars
+    if input_vars.kind_of?(Hash) &&
+       input_vars.keys.size == 1 &&
+       input_vars.keys.first == :input_vars &&
+       input_vars[:input_vars].kind_of?(Hash)
+      input_vars = input_vars[:input_vars]
+    end
+
+    input_vars
+  end
+
   private
 
   def job(action)
@@ -208,7 +224,7 @@ class ServiceTerraformTemplate < ServiceGeneric
 
     {
       :terraform_stack_id => action_job.options[:terraform_stack_id],
-      :input_vars         => action_job.options.dig(:input_vars, :input_vars).deep_dup
+      :input_vars         => ServiceTerraformTemplate.get_input_vars_from_job_options(action_job.options).deep_dup
     }
   end
 

--- a/app/models/service_terraform_template.rb
+++ b/app/models/service_terraform_template.rb
@@ -190,25 +190,22 @@ class ServiceTerraformTemplate < ServiceGeneric
   # - Service::service => ##
   def parse_dialog_options_only(action_options)
     dialog_options = action_options[:dialog] || {}
-    params = {}
-    dialog_options.each do |attr, val|
+    params = dialog_options.each_with_object({}) do |(attr, val), obj|
       if attr.start_with?("dialog_")
         var_key = attr.sub(/^(password::)?dialog_/, '')
-        params[var_key] = val
+        obj[var_key] = val
       end
     end
-    params.blank? ? {} : {:input_vars => params}
+    {:input_vars => params}
   end
 
   def parse_dialog_options(action_options)
     dialog_options = action_options[:dialog] || {}
-
     params = dialog_options.each_with_object({}) do |(attr, val), obj|
       var_key = attr.sub(/^(password::)?dialog_/, '')
       obj[var_key] = val
     end
-
-    params.blank? ? {} : {:input_vars => params}
+    {:input_vars => params}
   end
 
   def translate_credentials!(options)

--- a/app/models/service_terraform_template.rb
+++ b/app/models/service_terraform_template.rb
@@ -5,7 +5,6 @@ class ServiceTerraformTemplate < ServiceGeneric
     credential_id
     execution_ttl
     input_vars
-    # extra_vars
     verbosity
   ].freeze
 
@@ -138,11 +137,6 @@ class ServiceTerraformTemplate < ServiceGeneric
   def save_job_options(action, overrides)
     job_options = config_options(action)
 
-    # # TODO: check extra_vars
-    # job_options[:extra_vars].try(:transform_values!) do |val|
-    #   val.kind_of?(String) ? val : val[:default] # TODO: support Hash only
-    # end
-
     case action
     when ResourceAction::RETIREMENT
       # The Retirement(terraform destroy) action, itself does have dialog-options,
@@ -214,7 +208,6 @@ class ServiceTerraformTemplate < ServiceGeneric
 
     {
       :terraform_stack_id => action_job.options[:terraform_stack_id],
-      # :extra_vars         => action_job.options.dig(:input_vars, :extra_vars).deep_dup,
       :input_vars         => action_job.options.dig(:input_vars, :input_vars).deep_dup
     }
   end

--- a/app/models/service_terraform_template.rb
+++ b/app/models/service_terraform_template.rb
@@ -5,7 +5,7 @@ class ServiceTerraformTemplate < ServiceGeneric
     credential_id
     execution_ttl
     input_vars
-    extra_vars
+    # extra_vars
     verbosity
   ].freeze
 
@@ -137,10 +137,11 @@ class ServiceTerraformTemplate < ServiceGeneric
 
   def save_job_options(action, overrides)
     job_options = config_options(action)
-    # TODO: check extra_vars
-    job_options[:extra_vars].try(:transform_values!) do |val|
-      val.kind_of?(String) ? val : val[:default] # TODO: support Hash only
-    end
+
+    # # TODO: check extra_vars
+    # job_options[:extra_vars].try(:transform_values!) do |val|
+    #   val.kind_of?(String) ? val : val[:default] # TODO: support Hash only
+    # end
 
     case action
     when ResourceAction::RETIREMENT
@@ -213,7 +214,7 @@ class ServiceTerraformTemplate < ServiceGeneric
 
     {
       :terraform_stack_id => action_job.options[:terraform_stack_id],
-      :extra_vars         => action_job.options.dig(:input_vars, :extra_vars).deep_dup,
+      # :extra_vars         => action_job.options.dig(:input_vars, :extra_vars).deep_dup,
       :input_vars         => action_job.options.dig(:input_vars, :input_vars).deep_dup
     }
   end

--- a/spec/lib/terraform/runner/google_credential_spec.rb
+++ b/spec/lib/terraform/runner/google_credential_spec.rb
@@ -96,11 +96,5 @@ RSpec.describe(Terraform::Runner::GoogleCredential) do
         expect(cred.connection_parameters).to(eq(expected))
       end
     end
-
-    # describe "#extra_vars" do
-    #   it "returns an empty hash" do
-    #     expect(cred.extra_vars).to(eq({}))
-    #   end
-    # end
   end
 end

--- a/spec/lib/terraform/runner/openstack_credential_spec.rb
+++ b/spec/lib/terraform/runner/openstack_credential_spec.rb
@@ -119,11 +119,5 @@ RSpec.describe(Terraform::Runner::OpenstackCredential) do
         expect(cred.connection_parameters).to(eq(expected))
       end
     end
-
-    # describe "#extra_vars" do
-    #   it "returns an empty hash" do
-    #     expect(cred.extra_vars).to(eq({}))
-    #   end
-    # end
   end
 end

--- a/spec/models/dialog/terraform_template_service_dialog_spec.rb
+++ b/spec/models/dialog/terraform_template_service_dialog_spec.rb
@@ -46,78 +46,13 @@ RSpec.describe Dialog::TerraformTemplateServiceDialog do
       it_behaves_like "create_dialog with terraform template"
     end
 
-    # context "with no terraform template input vars, but with extra vars" do
-    #   let(:dialog_label) { 'mydialog1' }
-    #   let(:extra_vars) do
-    #     {
-    #       'some_extra_var'  => {:default => 'blah'},
-    #       'other_extra_var' => {:default => {'name' => 'some_value'}},
-    #       'array_extra_var' => {:default => [{'name' => 'some_value'}]}
-    #     }
-    #   end
-    #   let(:terraform_template) { terraform_template_with_no_input_vars }
-
-    #   it "creates a dialog with extra variables" do
-    #     dialog = subject.create_dialog(dialog_label, terraform_template, extra_vars)
-    #     expect(dialog).to have_attributes(:label => dialog_label, :buttons => "submit,cancel")
-
-    #     group = assert_variables_tab(dialog)
-    #     assert_extra_variables_group(group)
-    #   end
-    # end
-
     shared_examples_for "create_dialog with place-holder variable argument" do
       it "when no terraform template input vars and empty extra vars" do
-        dialog = described_class.create_dialog(dialog_label, terraform_template) # , extra_vars)
+        dialog = described_class.create_dialog(dialog_label, terraform_template)
         expect(dialog).to have_attributes(:label => dialog_label, :buttons => "submit,cancel")
 
         group = assert_variables_tab(dialog)
         assert_default_variables_group(group, dialog_label)
-      end
-    end
-
-    # context "when empty terraform template input vars & empty extra vars" do
-    #   let(:dialog_label) { "mydialog2" }
-    #   let(:terraform_template) { terraform_template_with_no_input_vars }
-    #   let(:extra_vars) do
-    #     {}
-    #   end
-
-    #   it_behaves_like "create_dialog with place-holder variable argument"
-    # end
-
-    # context "when nil terraform template & nil extra vars" do
-    #   let(:dialog_label) { "mydialog3" }
-    #   let(:terraform_template) { nil }
-    #   let(:extra_vars) { nil }
-
-    #   it_behaves_like "create_dialog with place-holder variable argument"
-    # end
-
-    context "with terraform template input vars and with extra vars" do
-      let(:dialog_label) { "mydialog4" }
-      # let(:extra_vars) do
-      #   {
-      #     'some_extra_var'  => {:default => 'blah'},
-      #     'other_extra_var' => {:default => {'name' => 'some_value'}},
-      #     'array_extra_var' => {:default => [{'name' => 'some_value'}]}
-      #   }
-      # end
-      let(:input_vars) do
-        require 'json'
-        payload = JSON.parse(payload_with_three_input_vars)
-        payload['input_vars']
-      end
-
-      it "creates multiple dialog-groups" do
-        dialog = subject.create_dialog(dialog_label, terraform_template_with_input_vars) # , extra_vars)
-        expect(dialog).to have_attributes(:label => dialog_label, :buttons => "submit,cancel")
-
-        group1 = assert_terraform_template_variables_tab(dialog, :group_size => 1)
-        assert_terraform_variables_group(group1, input_vars)
-
-        # group2 = assert_variables_tab(dialog, :group_size => 2)
-        # assert_extra_variables_group(group2)
       end
     end
 
@@ -126,13 +61,10 @@ RSpec.describe Dialog::TerraformTemplateServiceDialog do
       let(:input_vars) do
         [{"name" => "set_password", "label" => "set_password", "type" => "boolean", "description" => "Do you want to set the password ?", "required" => false, "secured" => false, "hidden" => false, "immutable" => false, "default" => true}]
       end
-      # let(:extra_vars) do
-      #   {}
-      # end
 
       it "create_dialog with checkbox field, when default value is true" do
         terraform_template = FactoryBot.create(:terraform_template, :payload => "{\"input_vars\": #{input_vars.to_json}}")
-        dialog = described_class.create_dialog(dialog_label, terraform_template) # , extra_vars)
+        dialog = described_class.create_dialog(dialog_label, terraform_template)
         expect(dialog).to have_attributes(:label => dialog_label, :buttons => "submit,cancel")
 
         group1 = assert_terraform_template_variables_tab(dialog, :group_size => 1)
@@ -144,7 +76,7 @@ RSpec.describe Dialog::TerraformTemplateServiceDialog do
         input_vars_copy[0]['default'] = "" # default attribute is empty
         terraform_template = FactoryBot.create(:terraform_template, :payload => "{\"input_vars\": #{input_vars_copy.to_json}}")
 
-        dialog = described_class.create_dialog(dialog_label, terraform_template) # , extra_vars)
+        dialog = described_class.create_dialog(dialog_label, terraform_template)
         expect(dialog).to have_attributes(:label => dialog_label, :buttons => "submit,cancel")
 
         group1 = assert_terraform_template_variables_tab(dialog, :group_size => 1)
@@ -156,7 +88,7 @@ RSpec.describe Dialog::TerraformTemplateServiceDialog do
         input_vars_copy[0].delete('default') # no default attribute
         terraform_template = FactoryBot.create(:terraform_template, :payload => "{\"input_vars\": #{input_vars_copy.to_json}}")
 
-        dialog = described_class.create_dialog(dialog_label, terraform_template) # , extra_vars)
+        dialog = described_class.create_dialog(dialog_label, terraform_template)
         expect(dialog).to have_attributes(:label => dialog_label, :buttons => "submit,cancel")
 
         group1 = assert_terraform_template_variables_tab(dialog, :group_size => 1)

--- a/spec/models/dialog/terraform_template_service_dialog_spec.rb
+++ b/spec/models/dialog/terraform_template_service_dialog_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Dialog::TerraformTemplateServiceDialog do
   describe "#create_dialog" do
     shared_examples_for "create_dialog with terraform template" do
       it "when has input vars" do
-        dialog = described_class.create_dialog(dialog_label, terraform_template, {})
+        dialog = described_class.create_dialog(dialog_label, terraform_template) # , {})
         expect(dialog).to have_attributes(:label => dialog_label, :buttons => "submit,cancel")
 
         group = assert_terraform_template_variables_tab(dialog)
@@ -46,29 +46,29 @@ RSpec.describe Dialog::TerraformTemplateServiceDialog do
       it_behaves_like "create_dialog with terraform template"
     end
 
-    context "with no terraform template input vars, but with extra vars" do
-      let(:dialog_label) { 'mydialog1' }
-      let(:extra_vars) do
-        {
-          'some_extra_var'  => {:default => 'blah'},
-          'other_extra_var' => {:default => {'name' => 'some_value'}},
-          'array_extra_var' => {:default => [{'name' => 'some_value'}]}
-        }
-      end
-      let(:terraform_template) { terraform_template_with_no_input_vars }
+    # context "with no terraform template input vars, but with extra vars" do
+    #   let(:dialog_label) { 'mydialog1' }
+    #   let(:extra_vars) do
+    #     {
+    #       'some_extra_var'  => {:default => 'blah'},
+    #       'other_extra_var' => {:default => {'name' => 'some_value'}},
+    #       'array_extra_var' => {:default => [{'name' => 'some_value'}]}
+    #     }
+    #   end
+    #   let(:terraform_template) { terraform_template_with_no_input_vars }
 
-      it "creates a dialog with extra variables" do
-        dialog = subject.create_dialog(dialog_label, terraform_template, extra_vars)
-        expect(dialog).to have_attributes(:label => dialog_label, :buttons => "submit,cancel")
+    #   it "creates a dialog with extra variables" do
+    #     dialog = subject.create_dialog(dialog_label, terraform_template, extra_vars)
+    #     expect(dialog).to have_attributes(:label => dialog_label, :buttons => "submit,cancel")
 
-        group = assert_variables_tab(dialog)
-        assert_extra_variables_group(group)
-      end
-    end
+    #     group = assert_variables_tab(dialog)
+    #     assert_extra_variables_group(group)
+    #   end
+    # end
 
     shared_examples_for "create_dialog with place-holder variable argument" do
       it "when no terraform template input vars and empty extra vars" do
-        dialog = described_class.create_dialog(dialog_label, terraform_template, extra_vars)
+        dialog = described_class.create_dialog(dialog_label, terraform_template) # , extra_vars)
         expect(dialog).to have_attributes(:label => dialog_label, :buttons => "submit,cancel")
 
         group = assert_variables_tab(dialog)
@@ -76,33 +76,33 @@ RSpec.describe Dialog::TerraformTemplateServiceDialog do
       end
     end
 
-    context "when empty terraform template input vars & empty extra vars" do
-      let(:dialog_label) { "mydialog2" }
-      let(:terraform_template) { terraform_template_with_no_input_vars }
-      let(:extra_vars) do
-        {}
-      end
+    # context "when empty terraform template input vars & empty extra vars" do
+    #   let(:dialog_label) { "mydialog2" }
+    #   let(:terraform_template) { terraform_template_with_no_input_vars }
+    #   let(:extra_vars) do
+    #     {}
+    #   end
 
-      it_behaves_like "create_dialog with place-holder variable argument"
-    end
+    #   it_behaves_like "create_dialog with place-holder variable argument"
+    # end
 
-    context "when nil terraform template & nil extra vars" do
-      let(:dialog_label) { "mydialog3" }
-      let(:terraform_template) { nil }
-      let(:extra_vars) { nil }
+    # context "when nil terraform template & nil extra vars" do
+    #   let(:dialog_label) { "mydialog3" }
+    #   let(:terraform_template) { nil }
+    #   let(:extra_vars) { nil }
 
-      it_behaves_like "create_dialog with place-holder variable argument"
-    end
+    #   it_behaves_like "create_dialog with place-holder variable argument"
+    # end
 
     context "with terraform template input vars and with extra vars" do
       let(:dialog_label) { "mydialog4" }
-      let(:extra_vars) do
-        {
-          'some_extra_var'  => {:default => 'blah'},
-          'other_extra_var' => {:default => {'name' => 'some_value'}},
-          'array_extra_var' => {:default => [{'name' => 'some_value'}]}
-        }
-      end
+      # let(:extra_vars) do
+      #   {
+      #     'some_extra_var'  => {:default => 'blah'},
+      #     'other_extra_var' => {:default => {'name' => 'some_value'}},
+      #     'array_extra_var' => {:default => [{'name' => 'some_value'}]}
+      #   }
+      # end
       let(:input_vars) do
         require 'json'
         payload = JSON.parse(payload_with_three_input_vars)
@@ -110,14 +110,14 @@ RSpec.describe Dialog::TerraformTemplateServiceDialog do
       end
 
       it "creates multiple dialog-groups" do
-        dialog = subject.create_dialog(dialog_label, terraform_template_with_input_vars, extra_vars)
+        dialog = subject.create_dialog(dialog_label, terraform_template_with_input_vars) # , extra_vars)
         expect(dialog).to have_attributes(:label => dialog_label, :buttons => "submit,cancel")
 
-        group1 = assert_terraform_template_variables_tab(dialog, :group_size => 2)
+        group1 = assert_terraform_template_variables_tab(dialog, :group_size => 1)
         assert_terraform_variables_group(group1, input_vars)
 
-        group2 = assert_variables_tab(dialog, :group_size => 2)
-        assert_extra_variables_group(group2)
+        # group2 = assert_variables_tab(dialog, :group_size => 2)
+        # assert_extra_variables_group(group2)
       end
     end
 
@@ -126,13 +126,13 @@ RSpec.describe Dialog::TerraformTemplateServiceDialog do
       let(:input_vars) do
         [{"name" => "set_password", "label" => "set_password", "type" => "boolean", "description" => "Do you want to set the password ?", "required" => false, "secured" => false, "hidden" => false, "immutable" => false, "default" => true}]
       end
-      let(:extra_vars) do
-        {}
-      end
+      # let(:extra_vars) do
+      #   {}
+      # end
 
       it "create_dialog with checkbox field, when default value is true" do
         terraform_template = FactoryBot.create(:terraform_template, :payload => "{\"input_vars\": #{input_vars.to_json}}")
-        dialog = described_class.create_dialog(dialog_label, terraform_template, extra_vars)
+        dialog = described_class.create_dialog(dialog_label, terraform_template) # , extra_vars)
         expect(dialog).to have_attributes(:label => dialog_label, :buttons => "submit,cancel")
 
         group1 = assert_terraform_template_variables_tab(dialog, :group_size => 1)
@@ -144,7 +144,7 @@ RSpec.describe Dialog::TerraformTemplateServiceDialog do
         input_vars_copy[0]['default'] = "" # default attribute is empty
         terraform_template = FactoryBot.create(:terraform_template, :payload => "{\"input_vars\": #{input_vars_copy.to_json}}")
 
-        dialog = described_class.create_dialog(dialog_label, terraform_template, extra_vars)
+        dialog = described_class.create_dialog(dialog_label, terraform_template) # , extra_vars)
         expect(dialog).to have_attributes(:label => dialog_label, :buttons => "submit,cancel")
 
         group1 = assert_terraform_template_variables_tab(dialog, :group_size => 1)
@@ -156,7 +156,7 @@ RSpec.describe Dialog::TerraformTemplateServiceDialog do
         input_vars_copy[0].delete('default') # no default attribute
         terraform_template = FactoryBot.create(:terraform_template, :payload => "{\"input_vars\": #{input_vars_copy.to_json}}")
 
-        dialog = described_class.create_dialog(dialog_label, terraform_template, extra_vars)
+        dialog = described_class.create_dialog(dialog_label, terraform_template) # , extra_vars)
         expect(dialog).to have_attributes(:label => dialog_label, :buttons => "submit,cancel")
 
         group1 = assert_terraform_template_variables_tab(dialog, :group_size => 1)
@@ -184,7 +184,7 @@ RSpec.describe Dialog::TerraformTemplateServiceDialog do
           {:position => 3, :value => JSON.pretty_generate(input_vars[3]['default'])}
         ]
 
-        dialog = described_class.create_dialog(dialog_label, terraform_template, {})
+        dialog = described_class.create_dialog(dialog_label, terraform_template) # , {})
         expect(dialog).to have_attributes(:label => dialog_label, :buttons => "submit,cancel")
 
         group1 = assert_terraform_template_variables_tab(dialog, :group_size => 1)
@@ -207,7 +207,7 @@ RSpec.describe Dialog::TerraformTemplateServiceDialog do
             {:position => 1, :value => JSON.pretty_generate(input_vars[1]['default'])}
           ]
 
-          dialog = described_class.create_dialog(dialog_label, terraform_template, {})
+          dialog = described_class.create_dialog(dialog_label, terraform_template) # , {})
           expect(dialog).to have_attributes(:label => dialog_label, :buttons => "submit,cancel")
 
           group1 = assert_terraform_template_variables_tab(dialog, :group_size => 1)
@@ -231,7 +231,7 @@ RSpec.describe Dialog::TerraformTemplateServiceDialog do
             {:position => 1, :value => nil}
           ]
 
-          dialog = described_class.create_dialog(dialog_label, terraform_template, {})
+          dialog = described_class.create_dialog(dialog_label, terraform_template) # , {})
           expect(dialog).to have_attributes(:label => dialog_label, :buttons => "submit,cancel")
 
           group1 = assert_terraform_template_variables_tab(dialog, :group_size => 1)

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/job_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/job_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
   let(:env_vars)    { {} }
   let(:input_vars)  do
     {
-      # :extra_vars => {"name" => "stack123"},
       :input_vars => {"name" => "stack123"}
     }
   end

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/job_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/job_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
   let(:env_vars)    { {} }
   let(:input_vars)  do
     {
-      :input_vars => {"name" => "stack123"}
+      "name" => "stack123"
     }
   end
   let(:credentials) { [] }
@@ -88,7 +88,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
       let(:action_type) { Terraform::Runner::ActionType::CREATE }
       let(:runner_options) do
         {
-          :input_vars                  => input_vars[:input_vars],
+          :input_vars                  => input_vars,
           :input_vars_type_constraints => {"name" => terraform_template_payload.dig(:input_vars, 0)},
           :credentials                 => [],
           :env_vars                    => {}
@@ -146,7 +146,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
         end
         let(:runner_options) do
           {
-            :input_vars                  => input_vars[:input_vars],
+            :input_vars                  => input_vars,
             :input_vars_type_constraints => {"name" => terraform_template_payload.dig(:input_vars, 0)},
             :credentials                 => [],
             :env_vars                    => {},
@@ -183,9 +183,6 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
           job.signal(signal.to_sym)
         end
       end
-    end
-
-    %w[start pre_execute execute poll_runner post_execute finish abort_job cancel error].each do |signal|
       shared_examples_for "doesn't allow #{signal} signal" do
         it signal.to_s do
           expect { job.signal(signal.to_sym) }.to raise_error(RuntimeError, /#{signal} is not permitted at state #{job.state}/)

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/job_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/job_spec.rb
@@ -15,7 +15,12 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
   end
   let(:state)       { "waiting_to_start" }
   let(:env_vars)    { {} }
-  let(:input_vars)  { {:extra_vars => {"name" => "stack123"}, :input_vars => {"name" => "stack123"}} }
+  let(:input_vars)  do
+    {
+      # :extra_vars => {"name" => "stack123"},
+      :input_vars => {"name" => "stack123"}
+    }
+  end
   let(:credentials) { [] }
   let(:terraform_stack_id) { '999-999-999-999' }
 

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/template_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/template_spec.rb
@@ -1,21 +1,18 @@
 RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Template do
   let(:template) { FactoryBot.create(:terraform_template) }
   let(:env_vars)    { {} }
-  # let(:extra_vars)  { {} }
   let(:credentials) { [] }
   let(:terraform_stack_id) { '999-999-999-999' }
 
   let(:provision_options) do
     {
       :env         => env_vars,
-      # :extra_vars => extra_vars,
       :credentials => credentials
     }
   end
   let(:retirement_options) do
     {
       :env                => env_vars,
-      # :extra_vars => extra_vars,
       :credentials        => credentials,
       :action             => ResourceAction::RETIREMENT,
       :terraform_stack_id => terraform_stack_id
@@ -31,9 +28,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Templa
         :options => {
           :template_id        => template.id,
           :env_vars           => env_vars,
-          :input_vars         => {
-            # :extra_vars => extra_vars
-          },
+          :input_vars         => {},
           :credentials        => credentials,
           :poll_interval      => 60,
           :action             => ResourceAction::PROVISION,
@@ -49,9 +44,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Templa
         :options => {
           :template_id        => template.id,
           :env_vars           => env_vars,
-          :input_vars         => {
-            # :extra_vars => extra_vars
-          },
+          :input_vars         => {},
           :credentials        => credentials,
           :poll_interval      => 60,
           :action             => ResourceAction::RETIREMENT,

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/template_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/template_spec.rb
@@ -1,15 +1,25 @@
 RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Template do
   let(:template) { FactoryBot.create(:terraform_template) }
   let(:env_vars)    { {} }
-  let(:extra_vars)  { {} }
+  # let(:extra_vars)  { {} }
   let(:credentials) { [] }
   let(:terraform_stack_id) { '999-999-999-999' }
 
   let(:provision_options) do
-    {:env => env_vars, :extra_vars => extra_vars, :credentials => credentials}
+    {
+      :env         => env_vars,
+      # :extra_vars => extra_vars,
+      :credentials => credentials
+    }
   end
   let(:retirement_options) do
-    {:env => env_vars, :extra_vars => extra_vars, :credentials => credentials, :action => ResourceAction::RETIREMENT, :terraform_stack_id => terraform_stack_id}
+    {
+      :env                => env_vars,
+      # :extra_vars => extra_vars,
+      :credentials        => credentials,
+      :action             => ResourceAction::RETIREMENT,
+      :terraform_stack_id => terraform_stack_id
+    }
   end
 
   describe "#run" do
@@ -21,7 +31,9 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Templa
         :options => {
           :template_id        => template.id,
           :env_vars           => env_vars,
-          :input_vars         => {:extra_vars => extra_vars},
+          :input_vars         => {
+            # :extra_vars => extra_vars
+          },
           :credentials        => credentials,
           :poll_interval      => 60,
           :action             => ResourceAction::PROVISION,
@@ -37,7 +49,9 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Templa
         :options => {
           :template_id        => template.id,
           :env_vars           => env_vars,
-          :input_vars         => {:extra_vars => extra_vars},
+          :input_vars         => {
+            # :extra_vars => extra_vars
+          },
           :credentials        => credentials,
           :poll_interval      => 60,
           :action             => ResourceAction::RETIREMENT,

--- a/spec/models/service_terraform_template_spec.rb
+++ b/spec/models/service_terraform_template_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ServiceTerraformTemplate do
           :execution_ttl                   => "",
           :log_output                      => "on_error",
           :verbosity                       => "0",
-          :extra_vars                      => {},
+          # :extra_vars                      => {},
           :configuration_script_payload_id => terraform_template.id,
           :dialog_id                       => 123,
           :fqname                          => ServiceTemplateTerraformTemplate.default_provisioning_entry_point
@@ -21,7 +21,7 @@ RSpec.describe ServiceTerraformTemplate do
           :execution_ttl                   => "",
           :log_output                      => "on_error",
           :verbosity                       => "0",
-          :extra_vars                      => {},
+          # :extra_vars                      => {},
           :configuration_script_payload_id => terraform_template.id,
           :dialog_id                       => 123,
           :fqname                          => ServiceTemplateTerraformTemplate.default_reconfiguration_entry_point
@@ -31,7 +31,7 @@ RSpec.describe ServiceTerraformTemplate do
           :execution_ttl                   => "",
           :log_output                      => "on_error",
           :verbosity                       => "0",
-          :extra_vars                      => {},
+          # :extra_vars                      => {},
           :configuration_script_payload_id => terraform_template.id,
           :dialog_id                       => 123,
           :fqname                          => ServiceTemplateTerraformTemplate.default_retirement_entry_point
@@ -70,7 +70,7 @@ RSpec.describe ServiceTerraformTemplate do
 
         expect(service.options[:provision_job_options]).to eq({
                                                                 "execution_ttl" => "",
-                                                                "extra_vars"    => {},
+                                                                # "extra_vars"    => {},
                                                                 "verbosity"     => "0",
                                                                 "input_vars"    => {
                                                                   "name" => "World"
@@ -86,7 +86,7 @@ RSpec.describe ServiceTerraformTemplate do
           s.add_resource!(stack, :name => ResourceAction::PROVISION)
           s.options.store(
             :provision_job_options, {"execution_ttl"          => "",
-                                     "extra_vars"             => {},
+                                     # "extra_vars"             => {},
                                      "verbosity"              => "0",
                                      "input_vars"             => {
                                        "name" => "World"
@@ -105,7 +105,7 @@ RSpec.describe ServiceTerraformTemplate do
           j.options = {
             :terraform_stack_id => terraform_stack_id,
             :input_vars         => {
-              :extra_vars => {},
+              # :extra_vars => {},
               :input_vars => {
                 "name" => "World"
               }
@@ -129,7 +129,7 @@ RSpec.describe ServiceTerraformTemplate do
 
         expect(service.options[:reconfigure_job_options]).to eq({
                                                                   "execution_ttl"      => "",
-                                                                  "extra_vars"         => {},
+                                                                  # "extra_vars"         => {},
                                                                   "verbosity"          => "0",
                                                                   "input_vars"         => {
                                                                     "name" => "New World"
@@ -148,7 +148,7 @@ RSpec.describe ServiceTerraformTemplate do
 
           s.options[:provision_job_options] = {
             :execution_ttl          => "",
-            :extra_vars             => {},
+            # :extra_vars             => {},
             :verbosity              => "0",
             :input_vars             => {
               "name" => "World"
@@ -159,7 +159,7 @@ RSpec.describe ServiceTerraformTemplate do
           }
           s.options[:reconfigure_job_options] = {
             :execution_ttl          => "",
-            :extra_vars             => {},
+            # :extra_vars             => {},
             :verbosity              => "0",
             :input_vars             => {
               "name" => "New World"
@@ -178,7 +178,7 @@ RSpec.describe ServiceTerraformTemplate do
           j.options = {
             :terraform_stack_id => terraform_stack_id,
             :input_vars         => {
-              :extra_vars => {},
+              # :extra_vars => {},
               :input_vars => {
                 "name" => "World"
               }
@@ -194,7 +194,7 @@ RSpec.describe ServiceTerraformTemplate do
           j.options = {
             :terraform_stack_id => terraform_stack_id,
             :input_vars         => {
-              :extra_vars => {},
+              # :extra_vars => {},
               :input_vars => {
                 "name" => "New World"
               }
@@ -208,7 +208,7 @@ RSpec.describe ServiceTerraformTemplate do
 
         expect(service.options[:retirement_job_options]).to eq({
                                                                  "execution_ttl"      => "",
-                                                                 "extra_vars"         => {},
+                                                                 # "extra_vars"         => {},
                                                                  "verbosity"          => "0",
                                                                  "input_vars"         => {
                                                                    "name" => "New World"
@@ -225,7 +225,7 @@ RSpec.describe ServiceTerraformTemplate do
           s.add_resource!(stack, :name => ResourceAction::PROVISION)
           s.options[:provision_job_options] = {
             :execution_ttl          => "",
-            :extra_vars             => {},
+            # :extra_vars             => {},
             :verbosity              => "0",
             :input_vars             => {
               "name" => "World"
@@ -244,7 +244,7 @@ RSpec.describe ServiceTerraformTemplate do
           j.options = {
             :terraform_stack_id => terraform_stack_id,
             :input_vars         => {
-              :extra_vars => {},
+              # :extra_vars => {},
               :input_vars => {
                 "name" => "World"
               }
@@ -258,7 +258,7 @@ RSpec.describe ServiceTerraformTemplate do
 
         expect(service.options[:retirement_job_options]).to eq({
                                                                  "execution_ttl"      => "",
-                                                                 "extra_vars"         => {},
+                                                                 # "extra_vars"         => {},
                                                                  "verbosity"          => "0",
                                                                  "input_vars"         => {
                                                                    "name" => "World"
@@ -464,7 +464,7 @@ RSpec.describe ServiceTerraformTemplate do
 
           s.options[:reconfigure_job_options] = {
             :execution_ttl          => "",
-            :extra_vars             => {},
+            # :extra_vars             => {},
             :verbosity              => "0",
             :input_vars             => {
               "name" => "New World"

--- a/spec/models/service_terraform_template_spec.rb
+++ b/spec/models/service_terraform_template_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe ServiceTerraformTemplate do
           :execution_ttl                   => "",
           :log_output                      => "on_error",
           :verbosity                       => "0",
-          # :extra_vars                      => {},
           :configuration_script_payload_id => terraform_template.id,
           :dialog_id                       => 123,
           :fqname                          => ServiceTemplateTerraformTemplate.default_provisioning_entry_point
@@ -21,7 +20,6 @@ RSpec.describe ServiceTerraformTemplate do
           :execution_ttl                   => "",
           :log_output                      => "on_error",
           :verbosity                       => "0",
-          # :extra_vars                      => {},
           :configuration_script_payload_id => terraform_template.id,
           :dialog_id                       => 123,
           :fqname                          => ServiceTemplateTerraformTemplate.default_reconfiguration_entry_point
@@ -31,7 +29,6 @@ RSpec.describe ServiceTerraformTemplate do
           :execution_ttl                   => "",
           :log_output                      => "on_error",
           :verbosity                       => "0",
-          # :extra_vars                      => {},
           :configuration_script_payload_id => terraform_template.id,
           :dialog_id                       => 123,
           :fqname                          => ServiceTemplateTerraformTemplate.default_retirement_entry_point
@@ -70,7 +67,6 @@ RSpec.describe ServiceTerraformTemplate do
 
         expect(service.options[:provision_job_options]).to eq({
                                                                 "execution_ttl" => "",
-                                                                # "extra_vars"    => {},
                                                                 "verbosity"     => "0",
                                                                 "input_vars"    => {
                                                                   "name" => "World"
@@ -86,7 +82,6 @@ RSpec.describe ServiceTerraformTemplate do
           s.add_resource!(stack, :name => ResourceAction::PROVISION)
           s.options.store(
             :provision_job_options, {"execution_ttl"          => "",
-                                     # "extra_vars"             => {},
                                      "verbosity"              => "0",
                                      "input_vars"             => {
                                        "name" => "World"
@@ -105,7 +100,6 @@ RSpec.describe ServiceTerraformTemplate do
           j.options = {
             :terraform_stack_id => terraform_stack_id,
             :input_vars         => {
-              # :extra_vars => {},
               :input_vars => {
                 "name" => "World"
               }
@@ -129,7 +123,6 @@ RSpec.describe ServiceTerraformTemplate do
 
         expect(service.options[:reconfigure_job_options]).to eq({
                                                                   "execution_ttl"      => "",
-                                                                  # "extra_vars"         => {},
                                                                   "verbosity"          => "0",
                                                                   "input_vars"         => {
                                                                     "name" => "New World"
@@ -148,7 +141,6 @@ RSpec.describe ServiceTerraformTemplate do
 
           s.options[:provision_job_options] = {
             :execution_ttl          => "",
-            # :extra_vars             => {},
             :verbosity              => "0",
             :input_vars             => {
               "name" => "World"
@@ -159,7 +151,6 @@ RSpec.describe ServiceTerraformTemplate do
           }
           s.options[:reconfigure_job_options] = {
             :execution_ttl          => "",
-            # :extra_vars             => {},
             :verbosity              => "0",
             :input_vars             => {
               "name" => "New World"
@@ -178,7 +169,6 @@ RSpec.describe ServiceTerraformTemplate do
           j.options = {
             :terraform_stack_id => terraform_stack_id,
             :input_vars         => {
-              # :extra_vars => {},
               :input_vars => {
                 "name" => "World"
               }
@@ -194,7 +184,6 @@ RSpec.describe ServiceTerraformTemplate do
           j.options = {
             :terraform_stack_id => terraform_stack_id,
             :input_vars         => {
-              # :extra_vars => {},
               :input_vars => {
                 "name" => "New World"
               }
@@ -208,7 +197,7 @@ RSpec.describe ServiceTerraformTemplate do
 
         expect(service.options[:retirement_job_options]).to eq({
                                                                  "execution_ttl"      => "",
-                                                                 # "extra_vars"         => {},
+
                                                                  "verbosity"          => "0",
                                                                  "input_vars"         => {
                                                                    "name" => "New World"
@@ -225,7 +214,6 @@ RSpec.describe ServiceTerraformTemplate do
           s.add_resource!(stack, :name => ResourceAction::PROVISION)
           s.options[:provision_job_options] = {
             :execution_ttl          => "",
-            # :extra_vars             => {},
             :verbosity              => "0",
             :input_vars             => {
               "name" => "World"
@@ -244,7 +232,6 @@ RSpec.describe ServiceTerraformTemplate do
           j.options = {
             :terraform_stack_id => terraform_stack_id,
             :input_vars         => {
-              # :extra_vars => {},
               :input_vars => {
                 "name" => "World"
               }
@@ -258,7 +245,6 @@ RSpec.describe ServiceTerraformTemplate do
 
         expect(service.options[:retirement_job_options]).to eq({
                                                                  "execution_ttl"      => "",
-                                                                 # "extra_vars"         => {},
                                                                  "verbosity"          => "0",
                                                                  "input_vars"         => {
                                                                    "name" => "World"
@@ -464,7 +450,6 @@ RSpec.describe ServiceTerraformTemplate do
 
           s.options[:reconfigure_job_options] = {
             :execution_ttl          => "",
-            # :extra_vars             => {},
             :verbosity              => "0",
             :input_vars             => {
               "name" => "New World"


### PR DESCRIPTION
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

We remove redundant extra_vars, as the extra_vars is not (addiiontionally) needed as input params (unlike in ansible)

For input params, we now have the input params for Terraform Template coming from service dialog.  As the service dialog for the Terraform Template now can be dynamically generated from Terrraform Template input parameters in UI.

Also includes minor review comment changes from https://github.com/ManageIQ/manageiq-providers-embedded_terraform/pull/94

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

Fixes #96

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
