### PR TITLE
Fix input_vars fetching from job options in Job

### DIFF
--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
@@ -1,9 +1,9 @@
 class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
-  def self.create_job(template, env_vars, input_vars, credentials, action: ResourceAction::PROVISION, terraform_stack_id: nil, poll_interval: 1.minute)
+  def self.create_job(template, env_vars, job_vars, credentials, action: ResourceAction::PROVISION, terraform_stack_id: nil, poll_interval: 1.minute)
     super(
       :template_id        => template.id,
       :env_vars           => env_vars,
-      :input_vars         => input_vars,
+      :job_vars           => job_vars,
       :credentials        => credentials,
       :poll_interval      => poll_interval,
       :action             => action,
@@ -178,7 +178,7 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
   end
 
   def input_vars
-    options.fetch(:input_vars, {})
+    options.dig(:job_vars, :input_vars) || {}
   end
 
   def terraform_runner_action_type(resource_action)

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/job_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/job_spec.rb
@@ -20,6 +20,13 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
       "name" => "stack123"
     }
   end
+  let(:job_vars) do
+    {
+      :execution_ttl => "",
+      :verbosity     => "0",
+      :input_vars    => input_vars
+    }
+  end
   let(:credentials) { [] }
   let(:terraform_stack_id) { '999-999-999-999' }
 
@@ -28,14 +35,14 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
       it "create a job" do
         expect(
           described_class.create_job(
-            template, env_vars, input_vars, credentials, :action => ResourceAction::PROVISION, :terraform_stack_id => nil
+            template, env_vars, job_vars, credentials, :action => ResourceAction::PROVISION, :terraform_stack_id => nil
           )
         ).to have_attributes(
           :type    => "ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job",
           :options => {
             :template_id        => template.id,
             :env_vars           => env_vars,
-            :input_vars         => input_vars,
+            :job_vars           => job_vars,
             :credentials        => credentials,
             :poll_interval      => 60,
             :action             => ResourceAction::PROVISION,
@@ -53,14 +60,14 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
         it "create a job" do
           expect(
             described_class.create_job(
-              template, env_vars, input_vars, credentials, :action => action, :terraform_stack_id => terraform_stack_id
+              template, env_vars, job_vars, credentials, :action => action, :terraform_stack_id => terraform_stack_id
             )
           ).to have_attributes(
             :type    => "ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job",
             :options => {
               :template_id        => template.id,
               :env_vars           => env_vars,
-              :input_vars         => input_vars,
+              :job_vars           => job_vars,
               :credentials        => credentials,
               :poll_interval      => 60,
               :action             => action,
@@ -78,7 +85,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
     context "with ResourceAction::PROVISION" do
       let(:job) do
         described_class.create_job(
-          template, env_vars, input_vars, credentials, :action => ResourceAction::PROVISION, :terraform_stack_id => nil
+          template, env_vars, job_vars, credentials, :action => ResourceAction::PROVISION, :terraform_stack_id => nil
         ).tap do |job|
           job.state = state
           job.options.store(:git_checkout_tempdir, git_checkout_tempdir)
@@ -90,7 +97,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
         {
           :input_vars                  => input_vars,
           :input_vars_type_constraints => {"name" => terraform_template_payload.dig(:input_vars, 0)},
-          :credentials                 => [],
+          :credentials                 => anything, # Authentication.where(credentials),
           :env_vars                    => {}
         }
       end
@@ -103,7 +110,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
         expect(job.options).to eq({
                                     :template_id            => template.id,
                                     :env_vars               => {},
-                                    :input_vars             => input_vars,
+                                    :job_vars               => job_vars,
                                     :credentials            => [],
                                     :poll_interval          => 1.minute,
                                     :action                 => ResourceAction::PROVISION,
@@ -121,7 +128,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
       context "with #{action}" do
         let(:job) do
           described_class.create_job(
-            template, env_vars, input_vars, credentials, :action => action, :terraform_stack_id => terraform_stack_id
+            template, env_vars, job_vars, credentials, :action => action, :terraform_stack_id => terraform_stack_id
           ).tap do |job|
             job.state = state
             job.options.store(:git_checkout_tempdir, git_checkout_tempdir)
@@ -148,7 +155,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
           {
             :input_vars                  => input_vars,
             :input_vars_type_constraints => {"name" => terraform_template_payload.dig(:input_vars, 0)},
-            :credentials                 => [],
+            :credentials                 => anything, # Authentication.where(credentials),
             :env_vars                    => {},
             :stack_id                    => terraform_stack_id
           }
@@ -162,7 +169,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
           expect(job.options).to eq({
                                       :template_id            => template.id,
                                       :env_vars               => {},
-                                      :input_vars             => input_vars,
+                                      :job_vars               => job_vars,
                                       :credentials            => [],
                                       :poll_interval          => 1.minute,
                                       :action                 => action,

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/job_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/job_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
         {
           :input_vars                  => input_vars,
           :input_vars_type_constraints => {"name" => terraform_template_payload.dig(:input_vars, 0)},
-          :credentials                 => anything, # Authentication.where(credentials),
+          :credentials                 => [],
           :env_vars                    => {}
         }
       end
@@ -155,7 +155,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
           {
             :input_vars                  => input_vars,
             :input_vars_type_constraints => {"name" => terraform_template_payload.dig(:input_vars, 0)},
-            :credentials                 => anything, # Authentication.where(credentials),
+            :credentials                 => [],
             :env_vars                    => {},
             :stack_id                    => terraform_stack_id
           }

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/template_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/template_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Templa
         :options => {
           :template_id        => template.id,
           :env_vars           => env_vars,
-          :input_vars         => {},
+          :job_vars           => {},
           :credentials        => credentials,
           :poll_interval      => 60,
           :action             => ResourceAction::PROVISION,
@@ -44,7 +44,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Templa
         :options => {
           :template_id        => template.id,
           :env_vars           => env_vars,
-          :input_vars         => {},
+          :job_vars           => {},
           :credentials        => credentials,
           :poll_interval      => 60,
           :action             => ResourceAction::RETIREMENT,


### PR DESCRIPTION
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

Fix the fetching of `:input_vars` from job options,  

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

Fixes #103 

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
