### PR TITLE
fix fetching input_vars from Provision job, in Retirement action

### DIFF
--- a/app/models/service_terraform_template.rb
+++ b/app/models/service_terraform_template.rb
@@ -119,7 +119,7 @@ class ServiceTerraformTemplate < ServiceGeneric
   def get_input_vars_from_job_options(job_options)
     return {} if job_options.nil?
 
-    input_vars = job_options.fetch(:input_vars, {})
+    input_vars = job_options.dig(:job_vars, :input_vars) || {}
 
     # Handle backward compatibility: nested :input_vars inside :input_vars
     if input_vars.kind_of?(Hash) &&

--- a/spec/models/service_terraform_template_spec.rb
+++ b/spec/models/service_terraform_template_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe ServiceTerraformTemplate do
         FactoryBot.create(:embedded_terraform_job).tap do |j|
           j.options = {
             :terraform_stack_id => terraform_stack_id,
-            :input_vars         => {
+            :job_vars           => {
               :input_vars => {
                 "name" => "World"
               }
@@ -168,7 +168,7 @@ RSpec.describe ServiceTerraformTemplate do
         FactoryBot.create(:embedded_terraform_job).tap do |j|
           j.options = {
             :terraform_stack_id => terraform_stack_id,
-            :input_vars         => {
+            :job_vars           => {
               :input_vars => {
                 "name" => "World"
               }
@@ -183,7 +183,7 @@ RSpec.describe ServiceTerraformTemplate do
         FactoryBot.create(:embedded_terraform_job).tap do |j|
           j.options = {
             :terraform_stack_id => terraform_stack_id,
-            :input_vars         => {
+            :job_vars           => {
               :input_vars => {
                 "name" => "New World"
               }
@@ -231,7 +231,7 @@ RSpec.describe ServiceTerraformTemplate do
         FactoryBot.create(:embedded_terraform_job).tap do |j|
           j.options = {
             :terraform_stack_id => terraform_stack_id,
-            :input_vars         => {
+            :job_vars           => {
               :input_vars => {
                 "name" => "World"
               }


### PR DESCRIPTION
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

Follow up PR to https://github.com/ManageIQ/manageiq-providers-embedded_terraform/pull/104


<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
