### PR TITLE
Fix sproadic test failure in db ordering

### DIFF
--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/configuration_script_source_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/configuration_script_source_spec.rb
@@ -186,14 +186,7 @@ RSpec.describe(ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Config
           names = names_and_payloads.collect(&:first)
           payloads = names_and_payloads.collect(&:second)
 
-          expect(names).to(
-            eq(
-              [
-                "templates/hello-world",
-                "templates/single-vm"
-              ]
-            )
-          )
+          expect(names).to(match_array(["templates/hello-world", "templates/single-vm"]))
 
           expected_hash1 = {
             "relative_path"     => File.dirname(multiple_templates_repo_structure.first),


### PR DESCRIPTION
@agrare Please review. Fixes:

```
   1) ManageIQ::Providers::EmbeddedTerraform::AutomationManager::ConfigurationScriptSource with a local repo create_in_provider runs sync with a multiple templates finds all templates
     Failure/Error:
       expect(names).to(
         eq(
           [
             "templates/hello-world",
             "templates/single-vm"
           ]
         )
       )

       expected: ["templates/hello-world", "templates/single-vm"]
            got: ["templates/single-vm", "templates/hello-world"]

       (compared using ==)
     # ./spec/models/manageiq/providers/embedded_terraform/automation_manager/configuration_script_source_spec.rb:189:in `block (5 levels) in <top (required)>'

```