### PR TITLE
Move `#run` back to `Template`

### DIFF
--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
@@ -1,7 +1,7 @@
 class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
-  def self.create_job(configuration_script, env_vars, job_vars, credentials, action: ResourceAction::PROVISION, terraform_stack_id: nil, poll_interval: 1.minute)
+  def self.create_job(template, env_vars, job_vars, credentials, action: ResourceAction::PROVISION, terraform_stack_id: nil, poll_interval: 1.minute)
     super(
-      :template_id        => configuration_script.id,
+      :template_id        => template.id,
       :env_vars           => env_vars,
       :job_vars           => job_vars,
       :credentials        => credentials,
@@ -115,16 +115,12 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
 
   private
 
-  def configuration_script
-    @configuration_script ||= self.class.module_parent::ConfigurationScript.find(options[:template_id])
-  end
-
-  def template_payload
-    @template_payload ||= configuration_script&.parent
+  def template
+    @template ||= self.class.module_parent::Template.find(options[:template_id])
   end
 
   def template_relative_path
-    JSON.parse(template_payload.payload)["relative_path"]
+    JSON.parse(template.payload)["relative_path"]
   end
 
   def stack_response
@@ -143,7 +139,7 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
   end
 
   def configuration_script_source
-    @configuration_script_source ||= configuration_script.configuration_script_source
+    @configuration_script_source ||= template.configuration_script_source
   end
 
   def queue_poll_runner
@@ -174,10 +170,10 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
   # @return [Hash]
   def input_vars_type_constraints
     require 'json'
-    payload = JSON.parse(template_payload.payload)
+    payload = JSON.parse(template.payload)
     (payload['input_vars'] || []).index_by { |v| v['name'] }
   rescue => error
-    $embedded_terraform_log.error("Failure in parsing payload for template/#{configuration_script.id}, caused by #{error.message}")
+    $embedded_terraform_log.error("Failure in parsing payload for template/#{template.id}, caused by #{error.message}")
     {}
   end
 

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/template.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/template.rb
@@ -1,3 +1,14 @@
 class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Template < ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptPayload
   has_many :stacks, :class_name => "ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack", :foreign_key => :configuration_script_base_id, :inverse_of => :configuration_script_payload, :dependent => :nullify
+
+  def run(vars = {}, _userid = nil)
+    env_vars    = vars.delete(:env) || {}
+    credentials = vars.delete(:credentials)
+    action = vars.delete(:action) || ResourceAction::PROVISION
+    terraform_stack_id = vars.delete(:terraform_stack_id)
+
+    self.class.module_parent::Job.create_job(
+      self, env_vars, vars, credentials, :action => action, :terraform_stack_id => terraform_stack_id
+    ).tap(&:signal_start)
+  end
 end

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/job_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/job_spec.rb
@@ -5,11 +5,10 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
       :relative_path => "terraform/templates/aws-instance-ec2-nano",
     }
   end
-  let(:configuration_script) { FactoryBot.create(:configuration_script_embedded_terraform, :parent => terraform_template) }
-  let(:terraform_template) { FactoryBot.create(:terraform_template, :payload => terraform_template_payload.to_json) }
+  let(:template) { FactoryBot.create(:terraform_template, :payload => terraform_template_payload.to_json) }
   let(:git_checkout_tempdir) { "/tmp" }
   let(:job) do
-    described_class.create_job(configuration_script, env_vars, input_vars, credentials).tap do |job|
+    described_class.create_job(template, env_vars, input_vars, credentials).tap do |job|
       job.state = state
       job.options.store(:git_checkout_tempdir, git_checkout_tempdir)
     end
@@ -36,12 +35,12 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
       it "create a job" do
         expect(
           described_class.create_job(
-            configuration_script, env_vars, job_vars, credentials, :action => ResourceAction::PROVISION, :terraform_stack_id => nil
+            template, env_vars, job_vars, credentials, :action => ResourceAction::PROVISION, :terraform_stack_id => nil
           )
         ).to have_attributes(
           :type    => "ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job",
           :options => {
-            :template_id        => configuration_script.id,
+            :template_id        => template.id,
             :env_vars           => env_vars,
             :job_vars           => job_vars,
             :credentials        => credentials,
@@ -61,12 +60,12 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
         it "create a job" do
           expect(
             described_class.create_job(
-              configuration_script, env_vars, job_vars, credentials, :action => action, :terraform_stack_id => terraform_stack_id
+              template, env_vars, job_vars, credentials, :action => action, :terraform_stack_id => terraform_stack_id
             )
           ).to have_attributes(
             :type    => "ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job",
             :options => {
-              :template_id        => configuration_script.id,
+              :template_id        => template.id,
               :env_vars           => env_vars,
               :job_vars           => job_vars,
               :credentials        => credentials,
@@ -86,7 +85,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
     context "with ResourceAction::PROVISION" do
       let(:job) do
         described_class.create_job(
-          configuration_script, env_vars, job_vars, credentials, :action => ResourceAction::PROVISION, :terraform_stack_id => nil
+          template, env_vars, job_vars, credentials, :action => ResourceAction::PROVISION, :terraform_stack_id => nil
         ).tap do |job|
           job.state = state
           job.options.store(:git_checkout_tempdir, git_checkout_tempdir)
@@ -109,7 +108,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
         job.execute
 
         expect(job.options).to eq({
-                                    :template_id            => configuration_script.id,
+                                    :template_id            => template.id,
                                     :env_vars               => {},
                                     :job_vars               => job_vars,
                                     :credentials            => [],
@@ -129,7 +128,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
       context "with #{action}" do
         let(:job) do
           described_class.create_job(
-            configuration_script, env_vars, job_vars, credentials, :action => action, :terraform_stack_id => terraform_stack_id
+            template, env_vars, job_vars, credentials, :action => action, :terraform_stack_id => terraform_stack_id
           ).tap do |job|
             job.state = state
             job.options.store(:git_checkout_tempdir, git_checkout_tempdir)
@@ -168,7 +167,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
           job.execute
 
           expect(job.options).to eq({
-                                      :template_id            => configuration_script.id,
+                                      :template_id            => template.id,
                                       :env_vars               => {},
                                       :job_vars               => job_vars,
                                       :credentials            => [],

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/template_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/template_spec.rb
@@ -1,5 +1,5 @@
-RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::ConfigurationScript do
-  let(:template) { FactoryBot.create(:configuration_script_embedded_terraform) }
+RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Template do
+  let(:template) { FactoryBot.create(:terraform_template) }
   let(:env_vars)    { {} }
   let(:credentials) { [] }
   let(:terraform_stack_id) { '999-999-999-999' }


### PR DESCRIPTION
Partially revert https://github.com/ManageIQ/manageiq-providers-embedded_terraform/pull/116 by undoing the changes to call `#run` through the `ConfigurationScript` but continue to create `ConfigurationScript` records in the repository `#sync`

```
ERROR – evm: MIQ(MiqGenericWorker::Runner) ID [75] PID [79552] GUID [d96e4660-33e1-4d41-98c2-62124889864a] An error has occurred during work processing: run must be implemented in a subclass
/var/www/miq/vmdb/app/models/configuration_script_payload.rb:13:in `run'
/opt/IBM/infrastructure-management-gemset/bundler/gems/bluecf-providers-embedded_terraform-910443a097f9/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb:31:in `raw_create_stack'
/opt/IBM/infrastructure-management-gemset/bundler/gems/bluecf-providers-embedded_terraform-910443a097f9/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb:14:in `create_stack'
/opt/IBM/infrastructure-management-gemset/bundler/gems/bluecf-providers-embedded_terraform-910443a097f9/app/models/service_terraform_template.rb:84:in `launch_terraform_template'
```

cc @putmanoj 
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
