### PR TITLE
Add service and template for miq_provision

### DIFF
--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/provision/state_machine.rb
@@ -7,6 +7,7 @@ module ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision::Sta
     stack = stack_klass.create_stack(source.terraform_template)
 
     phase_context[:stack_id] = stack.id
+    connect_to_service!(stack, :name => "Provision")
 
     save!
 

--- a/app/models/service_embedded_terraform.rb
+++ b/app/models/service_embedded_terraform.rb
@@ -1,2 +1,5 @@
 class ServiceEmbeddedTerraform < Service
+  def stack(action)
+    service_resources.find_by(:name => action, :resource_type => 'OrchestrationStack').try(:resource)
+  end
 end

--- a/app/models/service_embedded_terraform.rb
+++ b/app/models/service_embedded_terraform.rb
@@ -1,0 +1,2 @@
+class ServiceEmbeddedTerraform < Service
+end

--- a/app/models/service_template_embedded_terraform.rb
+++ b/app/models/service_template_embedded_terraform.rb
@@ -1,0 +1,2 @@
+class ServiceTemplateEmbeddedTerraform < ServiceTemplate
+end


### PR DESCRIPTION
`MiqProvisionWorkflow.class_for_platform` uses the prov_type to find the EMS class, so the `ServiceTemplate` name should match the prov_type and the vendor name.

Currently the only two that don't match this pattern are EmbeddedTerraform and EmbeddedAnsible.

Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/23772

Required for:
* https://github.com/ManageIQ/manageiq-ui-classic/pull/9869

https://github.com/ManageIQ/manageiq/issues/23775

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
