### PR TITLE
Add input vars and credential to ConfigurationScript provisioning & retirement

### DIFF
--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
@@ -12,10 +12,8 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
   end
 
   def target=(target)
-    return if target.nil?
-
-    self.target_class = target.class.name
-    self.target_id = target.id
+    self.target_class = target&.class&.name
+    self.target_id    = target&.id
   end
 
   def start

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
@@ -11,6 +11,13 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
     )
   end
 
+  def target=(target)
+    return if target.nil?
+
+    self.target_class = target.class.name
+    self.target_id = target.id
+  end
+
   def start
     queue_signal(:pre_execute)
   end

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/provision/state_machine.rb
@@ -4,11 +4,11 @@ module ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision::Sta
   end
 
   def provision
-    stack_opts = service.stack_opts
-    stack = stack_klass.create_stack(source.terraform_template, stack_opts)
+    stack_opts = service.stack_opts(ResourceAction::PROVISION, options)
+    stack = stack_klass.create_stack(source.terraform_template, stack_opts.dup)
 
     phase_context[:stack_id] = stack.id
-    connect_to_service!(stack, :name => "Provision")
+    connect_to_service!(stack, {:name => "Provision", :options => stack_opts})
 
     save!
 

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/provision/state_machine.rb
@@ -4,7 +4,8 @@ module ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision::Sta
   end
 
   def provision
-    stack = stack_klass.create_stack(source.terraform_template)
+    stack_opts = service.stack_opts
+    stack = stack_klass.create_stack(source.terraform_template, stack_opts)
 
     phase_context[:stack_id] = stack.id
     connect_to_service!(stack, :name => "Provision")

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/provision/state_machine.rb
@@ -69,25 +69,22 @@ module ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision::Sta
     return if stack.nil? || service.nil?
 
     job_options = stack.miq_task&.job&.options
-
     return if job_options.nil?
 
     terraform_runner_stack_id = job_options[:terraform_stack_id]
     terraform_runner_stack_job_id = job_options[:terraform_stack_job_id]
-
     return if terraform_runner_stack_id.blank?
 
     stack_resource = service.service_resources.find_by(:resource => stack)
-
     return if stack_resource.nil?
 
-    unless stack_resource.update(
+    stack_resource.update!(
       :options => stack_resource.options.merge(
         "terraform_runner_stack_id"     => terraform_runner_stack_id,
         "terraform_runner_stack_job_id" => terraform_runner_stack_job_id
       )
     )
-      $embedded_terraform_log.warn("Failed to update stack resource options")
-    end
+  rescue => err
+    $embedded_terraform_log.warn("Failed to update stack resource options : #{err.message}")
   end
 end

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/provision/state_machine.rb
@@ -85,6 +85,6 @@ module ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision::Sta
       )
     )
   rescue => err
-    $embedded_terraform_log.warn("Failed to update stack resource options : #{err.message}")
+    $embedded_terraform_log.warn("Failed to update stack resource options: #{err.message}")
   end
 end

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/provision/state_machine.rb
@@ -24,6 +24,8 @@ module ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision::Sta
   end
 
   def post_provision
+    update_stack_resource_data!
+
     if succeeded?
       signal :mark_as_completed
     else
@@ -54,5 +56,38 @@ module ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision::Sta
 
   def stack
     @stack ||= stack_klass.find(phase_context[:stack_id])
+  end
+
+  private
+
+  # Updates the service resource with terraform runner stack information
+  # that will be used during retirement actions.
+  #
+  # @return [void]
+  # @note This method is called during post_provision phase
+  def update_stack_resource_data!
+    return if stack.nil? || service.nil?
+
+    job_options = stack.miq_task&.job&.options
+
+    return if job_options.nil?
+
+    terraform_runner_stack_id = job_options[:terraform_stack_id]
+    terraform_runner_stack_job_id = job_options[:terraform_stack_job_id]
+
+    return if terraform_runner_stack_id.blank?
+
+    stack_resource = service.service_resources.find_by(:resource => stack)
+
+    return if stack_resource.nil?
+
+    unless stack_resource.update(
+      :options => stack_resource.options.merge(
+        "terraform_runner_stack_id"     => terraform_runner_stack_id,
+        "terraform_runner_stack_job_id" => terraform_runner_stack_job_id
+      )
+    )
+      $embedded_terraform_log.warn("Failed to update stack resource options")
+    end
   end
 end

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/provision_workflow.rb
@@ -9,4 +9,14 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::ProvisionWorkfl
       build_ci_hash_struct(cs, %w[name description manager_name])
     end
   end
+
+  def allowed_credentials(*_args)
+    ManageIQ::Providers::EmbeddedTerraform::AutomationManager::TemplateCredential.all.map do |auth|
+      build_ci_hash_struct(auth, %w[name type])
+    end
+  end
+
+  def self.default_dialog_file
+    'miq_provision_configuration_script_embedded_terraform_dialogs'
+  end
 end

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/provision_workflow.rb
@@ -11,8 +11,25 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::ProvisionWorkfl
   end
 
   def allowed_credentials(*_args)
-    ManageIQ::Providers::EmbeddedTerraform::AutomationManager::TemplateCredential.all.map do |auth|
-      build_ci_hash_struct(auth, %w[name type])
+    credential_type          = get_value(values[:credential_type])
+    allowed_credential_klass = credential_type&.safe_constantize || self.class.module_parent::TemplateCredential
+    allowed_credential_klass.all.to_h do |auth|
+      [auth.id, auth.name]
+    end
+  end
+
+  def allowed_credential_types(*_args)
+    credential_id = get_value(values[:credential_id])
+    credential    = self.class.module_parent::TemplateCredential.find_by(:id => credential_id) if credential_id
+
+    credential_classes = credential.present? ? [credential.class] : ManageIQ::Providers::EmbeddedTerraform::AutomationManager::TemplateCredential.descendants
+    credential_classes.to_h do |klass|
+      next unless klass.const_defined?(:API_OPTIONS)
+
+      api_options = klass::API_OPTIONS
+      next unless api_options[:label]
+
+      [klass.name, api_options[:label]]
     end
   end
 

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb
@@ -9,6 +9,8 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
     alias raw_create_job raw_create_stack
 
     def create_stack(terraform_template, options = {})
+      $embedded_terraform_log.debug("Creating job from template(#{terraform_template.name}) with options: #{options}")
+
       authentications = collect_authentications(terraform_template.manager, options)
 
       job = raw_create_stack(terraform_template, options)

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb
@@ -53,7 +53,8 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
   end
 
   def retireable?
-    true
+    # if service is a ServiceEmbeddedTerraform, then it is not retireable, using raw_delete_stack
+    service.instance_of?(ServiceEmbeddedTerraform)
   end
 
   def raw_delete_stack
@@ -90,8 +91,8 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
     if retiring?
       return if delete_miq_task.nil?
 
-      if raw_status.running? #  delete_job.is_active?
-        delete_job.poll_runner
+      if raw_status.running? #  delete_job&.is_active?
+        delete_job&.poll_runner
       end
       return
     end

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb
@@ -28,8 +28,7 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
         :status                       => miq_task&.state,
         :start_time                   => miq_task&.started_on
       ).tap do |stack|
-        job.target = stack
-        job.save!
+        job.update!(:target => stack)
       end
     end
 
@@ -209,9 +208,9 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
 
     Terraform::Runner.stack(terraform_stack_id)
   end
-end
 
-def handle_stack_operation_error(operation, err)
-  $embedded_terraform_log.error("Failed to #{operation}, error: #{err}")
-  raise MiqException::MiqOrchestrationProvisionError, err.message, err.backtrace
+  def handle_stack_operation_error(operation, err)
+    $embedded_terraform_log.error("Failed to #{operation}, error: #{err}")
+    raise MiqException::MiqOrchestrationProvisionError, err.message, err.backtrace
+  end
 end

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb
@@ -53,7 +53,8 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
   end
 
   def retireable?
-    # if service is a ServiceEmbeddedTerraform, then it is not retireable, using raw_delete_stack
+    # return false, if service is a ServiceTerraformTemplate, handles retire itself, raw_delete_stack should not be called.
+    # return true, if service is ServiceEmbeddedTerraform, raw_delete_stack should be called.
     service.instance_of?(ServiceEmbeddedTerraform)
   end
 
@@ -85,26 +86,26 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
   end
 
   def refresh
-    # when retiring
+    # when retired or retirement-failed, no further action required
     return if retired? || error_retiring?
 
+    # where retirement is running
     if retiring?
       return if delete_miq_task.nil?
 
-      if raw_status.running? #  delete_job&.is_active?
+      if raw_status.running? # delete_job&.is_active?
         delete_job&.poll_runner
       end
-      return
-    end
+    else
+      # when provisioning
+      return unless miq_task
 
-    # when provisioning
-    return unless miq_task
-
-    transaction do
-      self.status      = miq_task.state
-      self.start_time  = miq_task.started_on
-      self.finish_time = raw_status.completed? ? miq_task.updated_on : nil
-      save!
+      transaction do
+        self.status      = miq_task.state
+        self.start_time  = miq_task.started_on
+        self.finish_time = raw_status.completed? ? miq_task.updated_on : nil
+        save!
+      end
     end
   end
 
@@ -169,7 +170,7 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
   end
 
   def delete_job
-    @delete_job ||= ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job.find_by(:target_id => id)
+    @delete_job ||= ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job.find_by(:target_id => id, :target_class => self.class.name)
   end
 
   def delete_miq_task

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb
@@ -33,8 +33,7 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
     def raw_create_stack(terraform_template, options = {})
       terraform_template.run(options)
     rescue => err
-      $embedded_terraform_log.error("Failed to create job from template(#{terraform_template.name}), error: #{err}")
-      raise MiqException::MiqOrchestrationProvisionError, err.to_s, err.backtrace
+      handle_stack_operation_error("create job from template(#{terraform_template.name})", err)
     end
 
     def status_class
@@ -50,7 +49,37 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
     end
   end
 
+  def retireable?
+    true
+  end
+
+  def raw_delete_stack
+    raise MiqException::Error, "Cannot delete stack, service_resource not found for stack:#{id}" if service_resource.nil?
+    raise MiqException::Error, "Cannot delete stack, service_resource.options is empty for stack:#{id}" if service_resource.options.blank?
+
+    terraform_runner_stack_id = service_resource.options["terraform_runner_stack_id"]
+    raise MiqException::MiqOrchestrationProvisionError, "Cannot delete stack, did not find terraform_runner_stack_id for stack:#{id}" if terraform_runner_stack_id.blank?
+
+    terraform_template = configuration_script_payload
+    raise MiqException::Error, "Cannot delete stack, configuration script payload not found for stack:#{id}" if terraform_template.nil?
+
+    job_options = service_resource.options.slice("input_vars", "credentials")
+    job_options[:action] = ResourceAction::RETIREMENT
+    job_options[:terraform_stack_id] = terraform_runner_stack_id
+
+    $embedded_terraform_log.debug("Run job to delete stack(#{id}) for template(#{terraform_template.name}) with options: #{job_options}")
+
+    delete_job = terraform_template.run(job_options)
+
+    $embedded_terraform_log.debug("Delete job created : #{delete_job.id}")
+    delete_job
+  rescue => err
+    handle_stack_operation_error("delete stack for stack:#{id}", err)
+  end
+
   def refresh
+    return unless miq_task
+
     transaction do
       self.status      = miq_task.state
       self.start_time  = miq_task.started_on
@@ -60,8 +89,12 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
   end
 
   def raw_status
+    return nil unless miq_task
+
     Status.new(miq_task)
   end
+
+  delegate :normalized_live_status, :to => :raw_status, :allow_nil => true
 
   # Intend to be called by UI to display stdout. The stdout is stored in TerraformRunner(api/stack#message)
   def raw_stdout_via_worker(userid, format = 'txt')
@@ -107,16 +140,47 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
     TerminalToHtml.render(text)
   end
 
+  def service_resource
+    @service_resource ||= service_resources.find_by(:resource => self)
+  end
+
   private
 
   def terraform_runner_stack_data
-    return if miq_task.nil? || miq_task.job.nil?
+    if service_resource.present?
+      terraform_runner_stack_id = service_resource.options&.dig("terraform_runner_stack_id")
+
+      return Terraform::Runner.stack(terraform_runner_stack_id) if terraform_runner_stack_id.present?
+    else
+      $embedded_terraform_log.warn("Unable to retrieve stack data for stack(#{id}): service_resource is nil")
+    end
+
+    # This means, it is a legacy stack, before we introduced the workflow provision
+    if miq_task.nil?
+      $embedded_terraform_log.warn("Unable to retrieve stack data for stack(#{id}): miq_task is nil")
+      return
+    end
+
+    if miq_task.job.nil?
+      $embedded_terraform_log.warn("Unable to retrieve stack data for stack(#{id}): miq_task.job is nil")
+      return
+    end
 
     job = miq_task.job
     terraform_stack_id = job.options[:terraform_stack_id]
 
-    return if terraform_stack_id.blank?
+    if terraform_stack_id.blank?
+      $embedded_terraform_log.warn("Unable to retrieve stack data for stack(#{id}): terraform_stack_id is blank in job options")
+      return
+    end
 
     Terraform::Runner.stack(terraform_stack_id)
   end
+end
+
+private
+
+def handle_stack_operation_error(operation, err)
+  $embedded_terraform_log.error("Failed to #{operation}, error: #{err}")
+  raise MiqException::MiqOrchestrationProvisionError, err.message, err.backtrace
 end

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb
@@ -27,7 +27,10 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
         :miq_task                     => miq_task,
         :status                       => miq_task&.state,
         :start_time                   => miq_task&.started_on
-      )
+      ).tap do |stack|
+        job.target = stack
+        job.save!
+      end
     end
 
     def raw_create_stack(terraform_template, options = {})
@@ -69,15 +72,31 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
 
     $embedded_terraform_log.debug("Run job to delete stack(#{id}) for template(#{terraform_template.name}) with options: #{job_options}")
 
-    delete_job = terraform_template.run(job_options)
+    @delete_job = terraform_template.run(job_options)
+    delete_job.target = self
+    delete_job.save!
 
     $embedded_terraform_log.debug("Delete job created : #{delete_job.id}")
+
     delete_job
   rescue => err
     handle_stack_operation_error("delete stack for stack:#{id}", err)
   end
 
   def refresh
+    # when retiring
+    return if retired? || error_retiring?
+
+    if retiring?
+      return if delete_miq_task.nil?
+
+      if raw_status.running? #  delete_job.is_active?
+        delete_job.poll_runner
+      end
+      return
+    end
+
+    # when provisioning
     return unless miq_task
 
     transaction do
@@ -88,10 +107,14 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
     end
   end
 
+  def queue_refresh
+    MiqQueue.put(:class_name => self.class.name, :instance_id => id, :method_name => "refresh", :role => "embedded_terraform")
+  end
+
   def raw_status
     return nil unless miq_task
 
-    Status.new(miq_task)
+    Status.new(self)
   end
 
   delegate :normalized_live_status, :to => :raw_status, :allow_nil => true
@@ -144,6 +167,14 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
     @service_resource ||= service_resources.find_by(:resource => self)
   end
 
+  def delete_job
+    @delete_job ||= ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job.find_by(:target_id => id)
+  end
+
+  def delete_miq_task
+    @delete_miq_task ||= delete_job&.miq_task
+  end
+
   private
 
   def terraform_runner_stack_data
@@ -177,8 +208,6 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
     Terraform::Runner.stack(terraform_stack_id)
   end
 end
-
-private
 
 def handle_stack_operation_error(operation, err)
   $embedded_terraform_log.error("Failed to #{operation}, error: #{err}")

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/stack/status.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/stack/status.rb
@@ -1,7 +1,7 @@
 class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack::Status < OrchestrationStack::Status
   LIVE_STATUS_RUNNING = 'running'.freeze
   LIVE_STATUS_CREATED = 'create_complete'.freeze
-  LIVE_STATUS_FAILED = 'failed'.freeze
+  LIVE_STATUS_FAILED  = 'failed'.freeze
   LIVE_STATUS_DELETED = 'delete_complete'.freeze
 
   attr_accessor :task_status, :stack

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/stack/status.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/stack/status.rb
@@ -1,4 +1,8 @@
 class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack::Status < OrchestrationStack::Status
+  LIVE_STATUS_RUNNING = 'running'.freeze
+  LIVE_STATUS_FINISHED = 'finished'.freeze
+  LIVE_STATUS_FAILED = 'failed'.freeze
+
   attr_accessor :task_status
 
   def initialize(miq_task)
@@ -16,5 +20,12 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack::Status <
 
   def failed?
     completed? && task_status != MiqTask::STATUS_OK
+  end
+
+  def normalized_live_status
+    return [LIVE_STATUS_RUNNING, reason || status] unless completed?
+    return [LIVE_STATUS_FINISHED, reason || 'OK'] if succeeded?
+
+    [LIVE_STATUS_FAILED, reason || 'Stack creation failed']
   end
 end

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/stack/status.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/stack/status.rb
@@ -1,13 +1,33 @@
 class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack::Status < OrchestrationStack::Status
   LIVE_STATUS_RUNNING = 'running'.freeze
-  LIVE_STATUS_FINISHED = 'finished'.freeze
+  LIVE_STATUS_CREATED = 'create_complete'.freeze
   LIVE_STATUS_FAILED = 'failed'.freeze
+  LIVE_STATUS_DELETED = 'delete_complete'.freeze
 
-  attr_accessor :task_status
+  attr_accessor :task_status, :stack
 
-  def initialize(miq_task)
+  def initialize(stack)
+    self.stack = stack
+    miq_task = (stack.delete_miq_task.presence || stack.miq_task)
+
     super(miq_task.state, miq_task.message)
     self.task_status = miq_task.status
+  end
+
+  def retiring?
+    stack.retiring? || (stack.delete_miq_task.present? && running?)
+  end
+
+  def retired?
+    stack.retired? || (stack.delete_miq_task.present? && succeeded?)
+  end
+
+  def error_retiring?
+    stack.error_retiring? || (stack.delete_miq_task.present? && failed?)
+  end
+
+  def running?
+    !completed?
   end
 
   def completed?
@@ -23,9 +43,19 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack::Status <
   end
 
   def normalized_live_status
-    return [LIVE_STATUS_RUNNING, reason || status] unless completed?
-    return [LIVE_STATUS_FINISHED, reason || 'OK'] if succeeded?
+    # if running
+    return [LIVE_STATUS_RUNNING, reason || status] if running?
 
+    # if retired?
+    return [LIVE_STATUS_DELETED, reason || 'Stack was deleted'] if retired?
+
+    # if created?
+    return [LIVE_STATUS_CREATED, reason || 'OK'] if succeeded?
+
+    # if retire failed?
+    return [LIVE_STATUS_FAILED, reason || 'Stack deletion failed'] if error_retiring?
+
+    # if provision failed?
     [LIVE_STATUS_FAILED, reason || 'Stack creation failed']
   end
 end

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/stack/status.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/stack/status.rb
@@ -8,7 +8,7 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack::Status <
 
   def initialize(stack)
     self.stack = stack
-    miq_task = (stack.delete_miq_task.presence || stack.miq_task)
+    miq_task   = stack.delete_miq_task.presence || stack.miq_task
 
     super(miq_task.state, miq_task.message)
     self.task_status = miq_task.status

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/template.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/template.rb
@@ -1,7 +1,8 @@
 class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Template < ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptPayload
   has_many :stacks, :class_name => "ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack", :foreign_key => :configuration_script_base_id, :inverse_of => :configuration_script_payload, :dependent => :nullify
 
-  def run(vars = {}, _userid = nil)
+  def run(opts = {}, _userid = nil)
+    vars = opts.dup
     env_vars    = vars.delete(:env) || {}
     credentials = vars.delete(:credentials)
     action = vars.delete(:action) || ResourceAction::PROVISION

--- a/app/models/service_embedded_terraform.rb
+++ b/app/models/service_embedded_terraform.rb
@@ -1,4 +1,6 @@
 class ServiceEmbeddedTerraform < Service
+  include ServiceEmbeddedTerraformMixin
+
   def stack(action)
     service_resources.find_by(:name => action, :resource_type => 'OrchestrationStack').try(:resource)
   end

--- a/app/models/service_embedded_terraform_mixin.rb
+++ b/app/models/service_embedded_terraform_mixin.rb
@@ -26,6 +26,10 @@ module ServiceEmbeddedTerraformMixin
   def stack_opts(action = ResourceAction::PROVISION, overrides = {})
     stack_opts = {:action => action}.merge(input_vars_from_dialog(options.merge(overrides)))
 
+    if instance_of?(ServiceEmbeddedTerraform)
+      stack_opts[:credential_id] = credential_id_from_workflow_provision_request(overrides)
+    end
+
     translate_credentials!(stack_opts)
 
     stack_opts
@@ -167,5 +171,14 @@ module ServiceEmbeddedTerraformMixin
   #   - verbosity
   def config_options!(action)
     options.fetch_path(:config_info, action.downcase.to_sym).slice(*CONFIG_OPTIONS_WHITELIST).with_indifferent_access if options.key?(:config_info)
+  end
+
+  def credential_id_from_workflow_provision_request(request_options)
+    credential_id = request_options[:credential_id]
+
+    # If for provision_workflow, coming from customize tab, it will have a array like [id, name], and we only take id
+    credential_id = credential_id.first if credential_id.kind_of?(Array) && credential_id.first.present?
+
+    credential_id
   end
 end

--- a/app/models/service_embedded_terraform_mixin.rb
+++ b/app/models/service_embedded_terraform_mixin.rb
@@ -1,0 +1,171 @@
+module ServiceEmbeddedTerraformMixin
+  extend ActiveSupport::Concern
+
+  # Builds stack options for Terraform operations
+  #
+  # This method constructs a hash of options needed for Terraform stack operations,
+  # combining the action type with input variables from dialog options and any overrides.
+  # It also translates credential references into their native format.
+  #
+  # @param action [String] The action to perform (default: ResourceAction::PROVISION)
+  #                        Common values include PROVISION, RETIREMENT, etc.
+  # @param overrides [Hash] Additional options to merge with the service options (default: {})
+  #
+  # @return [Hash] A hash containing:
+  #   - :action [String] The action type
+  #   - :input_vars [Hash] Input variables extracted from dialog
+  #   - :credentials [Array] Array of credential native references
+  #
+  # @example Building stack options for provisioning
+  #   stack_opts(ResourceAction::PROVISION)
+  #   # => { action: "Provision", input_vars: {...}, credentials: [...] }
+  #
+  # @example Building stack options with overrides
+  #   stack_opts(ResourceAction::PROVISION, { credential_id: 123 })
+  #   # => { action: "Provision", input_vars: {...}, credentials: [credential_ref] }
+  def stack_opts(action = ResourceAction::PROVISION, overrides = {})
+    stack_opts = {:action => action}.merge(input_vars_from_dialog(options.merge(overrides)))
+
+    translate_credentials!(stack_opts)
+
+    stack_opts
+  end
+
+  CONFIG_OPTIONS_WHITELIST = %i[
+    credential_id
+    execution_ttl
+    input_vars
+    verbosity
+  ].freeze
+
+  private
+
+  # Extracts and transforms input variables from service dialog options
+  #
+  # This method processes dialog options to extract Terraform input variables,
+  # removing the "dialog_" prefix and optional "password::" prefix from attribute names.
+  #
+  # @param service_options [Hash] The service options hash containing dialog data
+  # @param only_dialog [Boolean] When true, only processes attributes starting with "dialog_"
+  #                               When false, processes all attributes in the dialog hash
+  #
+  # @return [Hash] A hash with a single :input_vars key containing the transformed variables
+  #
+  # @example Processing all dialog attributes (only_dialog: false, default)
+  #   service_options = {
+  #     dialog: {
+  #       "dialog_var1" => "value1",
+  #       "password::dialog_secret" => "value2",
+  #       "other_param" => "value3"
+  #     }
+  #   }
+  #   input_vars_from_dialog(service_options)
+  #   # => { input_vars: { "var1" => "value1", "secret" => "value2", "other_param" => "value3" } }
+  #
+  # @example Processing only dialog-prefixed attributes (only_dialog: true)
+  #   service_options = {
+  #     dialog: {
+  #       "dialog_var1" => "value1",
+  #       "password::dialog_secret" => "value2",
+  #       "other_param" => "value3"
+  #     }
+  #   }
+  #   input_vars_from_dialog(service_options, only_dialog: true)
+  #   # => { input_vars: { "var1" => "value1", "secret" => "value2" } }
+  #
+  # @example Handling invalid input
+  #   input_vars_from_dialog(nil)
+  #   # => { input_vars: {} }
+  #
+  # @note The method strips the following prefixes from attribute names:
+  #   - "dialog_" - Standard dialog field prefix
+  #   - "password::dialog_" - Password-protected dialog field prefix
+  def input_vars_from_dialog(service_options = nil, only_dialog: false)
+    # Handle backward compatibility: support both positional and keyword arguments
+    # When called as input_vars_from_dialog(action_options, true)
+    if service_options.nil?
+      service_options = options
+    end
+
+    # Validate input parameter
+    return {:input_vars => {}} unless service_options.kind_of?(Hash)
+
+    dialog_options = service_options.fetch(:dialog, {})
+
+    input_vars = dialog_options.each_with_object({}) do |(attr, val), result|
+      attr_str = attr.to_s
+
+      # Skip non-dialog attributes when only_dialog is true
+      next if only_dialog && !attr_str.start_with?("dialog_", "password::dialog_")
+
+      # Extract variable key by removing password:: and dialog_ prefixes
+      var_key = attr_str.sub(/\A(?:password::)?dialog_/, '')
+      result[var_key] = val unless var_key.empty?
+    end
+
+    {:input_vars => input_vars}
+  end
+
+  # Translates credential IDs into native credential references
+  #
+  # This method modifies the options hash in-place, removing the :credential_id key
+  # and adding a :credentials array containing the native reference of the credential.
+  # If no credential_id is present, an empty credentials array is set.
+  #
+  # @param options [Hash] The options hash to modify
+  #   - :credential_id [Integer, nil] The ID of the credential to translate
+  #
+  # @return [void] Modifies the options hash in-place
+  #
+  # @example With a credential ID
+  #   options = { credential_id: 123 }
+  #   translate_credentials!(options)
+  #   # options is now: { credentials: [<native_ref>] }
+  #
+  # @example Without a credential ID
+  #   options = {}
+  #   translate_credentials!(options)
+  #   # options is now: { credentials: [] }
+  #
+  # @note This method mutates the input hash by:
+  #   - Removing the :credential_id key
+  #   - Adding a :credentials key with an array value
+  def translate_credentials!(options)
+    options[:credentials] = []
+
+    credential_id = options.delete(:credential_id)
+    options[:credentials] << Authentication.find(credential_id).native_ref if credential_id.present?
+  end
+
+  # Extracts whitelisted configuration options for a specific action
+  #
+  # This method retrieves configuration options from the service's config_info hash
+  # for a given action, filtering them to only include whitelisted options defined
+  # in CONFIG_OPTIONS_WHITELIST.
+  #
+  # @param action [String] The action name (e.g., "Provision", "Retirement")
+  #                        Will be converted to lowercase symbol for lookup
+  #
+  # @return [ActiveSupport::HashWithIndifferentAccess, nil]
+  #   A hash containing only whitelisted config options if config_info exists,
+  #   nil if config_info is not present in options
+  #
+  # @example Retrieving provision config options
+  #   # Assuming options = { config_info: { provision: { credential_id: 1, verbosity: 2, other: 3 } } }
+  #   config_options!("Provision")
+  #   # => { "credential_id" => 1, "verbosity" => 2 }
+  #
+  # @example When config_info is not present
+  #   # Assuming options = {}
+  #   config_options!("Provision")
+  #   # => nil
+  #
+  # @note Only options listed in CONFIG_OPTIONS_WHITELIST are returned:
+  #   - credential_id
+  #   - execution_ttl
+  #   - input_vars
+  #   - verbosity
+  def config_options!(action)
+    options.fetch_path(:config_info, action.downcase.to_sym).slice(*CONFIG_OPTIONS_WHITELIST).with_indifferent_access if options.key?(:config_info)
+  end
+end

--- a/app/models/service_terraform_template.rb
+++ b/app/models/service_terraform_template.rb
@@ -1,4 +1,6 @@
 class ServiceTerraformTemplate < ServiceGeneric
+  include ServiceEmbeddedTerraformMixin
+
   delegate :terraform_template, :to => :service_template, :allow_nil => true
 
   CONFIG_OPTIONS_WHITELIST = %i[
@@ -166,13 +168,17 @@ class ServiceTerraformTemplate < ServiceGeneric
       # We need the stack_id from Provision, then we override with update_options from Reconfiguration request
       prov_job_options = copy_terraform_stack_id_and_input_vars_from_job_options(ResourceAction::PROVISION)
       job_options.deep_merge!(prov_job_options)
-      job_options.deep_merge!(parse_dialog_options_only(overrides))
+
+      # We only want keys starting with 'dialog_', as these are user inputs, don't want other key/value pairs.
+      # Particularly in case of Reconfigure action, we use :only_dialog = true, as we want to remove keys like,
+      # - request => "service_reconfigure"
+      # - Service::service => ##
+      job_options.deep_merge!(input_vars_from_dialog(overrides, :only_dialog => true))
     else
       # For Provision
-      job_options.deep_merge!(parse_dialog_options(options))
+      job_options.deep_merge!(input_vars_from_dialog(options))
     end
 
-    #  job_options.deep_merge!(overrides)
     translate_credentials!(job_options)
 
     options[job_option_key(action)] = job_options
@@ -180,38 +186,7 @@ class ServiceTerraformTemplate < ServiceGeneric
   end
 
   def job_option_key(action)
-    "#{action.downcase}_job_options".to_sym
-  end
-
-  # We only want keys starting with 'dialog_', as these are user inputs, don't want other key/value pairs.
-  # Particularly in case of Reconfigure action, we want to remove keys like,
-  # - request => "service_reconfigure"
-  # - Service::service => ##
-  def parse_dialog_options_only(action_options)
-    dialog_options = action_options[:dialog] || {}
-    params = dialog_options.each_with_object({}) do |(attr, val), obj|
-      if attr.start_with?("dialog_")
-        var_key = attr.sub(/^(password::)?dialog_/, '')
-        obj[var_key] = val
-      end
-    end
-    {:input_vars => params}
-  end
-
-  def parse_dialog_options(action_options)
-    dialog_options = action_options[:dialog] || {}
-    params = dialog_options.each_with_object({}) do |(attr, val), obj|
-      var_key = attr.sub(/^(password::)?dialog_/, '')
-      obj[var_key] = val
-    end
-    {:input_vars => params}
-  end
-
-  def translate_credentials!(options)
-    options[:credentials] = []
-
-    credential_id = options.delete(:credential_id)
-    options[:credentials] << Authentication.find(credential_id).native_ref if credential_id.present?
+    :"#{action.downcase}_job_options"
   end
 
   def copy_terraform_stack_id_and_input_vars_from_job_options(action)

--- a/content/miq_dialogs/miq_provision_configuration_script_embedded_terraform_dialogs.yaml
+++ b/content/miq_dialogs/miq_provision_configuration_script_embedded_terraform_dialogs.yaml
@@ -124,6 +124,37 @@
     :customize:
       :description: Customize
       :fields:
+        :verbosity:
+          :description: Verbosity
+          :values:
+            0: Normal
+            1: Verbose
+            2: More Verbose
+            3: Debug
+            4: Connection Debug
+            5: WinRM Debug
+          :notes:
+          :required: false
+          :display: :edit
+          :default: 0
+          :data_type: :integer
+        :log_output:
+          :description: Log Output
+          :values:
+            on_error: On Error
+            always: Always
+            never: Never
+          :notes:
+          :required: false
+          :display: :edit
+          :default: on_error
+          :data_type: :string
+        :execution_ttl:
+          :description: Max TTL (mins)
+          :notes:
+          :required: false
+          :display: :edit
+          :data_type: :integer
         :credential_id:
           :values_from:
             :method: :allowed_credentials

--- a/content/miq_dialogs/miq_provision_configuration_script_embedded_terraform_dialogs.yaml
+++ b/content/miq_dialogs/miq_provision_configuration_script_embedded_terraform_dialogs.yaml
@@ -1,0 +1,176 @@
+---
+:name: miq_provision_configuration_script_embedded_terraform_dialogs
+:description: Embedded Terraform Configuration Script Provisioning Dialog
+:dialog_type: MiqProvisionConfigurationScriptWorkflow
+:content:
+  :buttons:
+  - :submit
+  - :cancel
+  :dialogs:
+    :requester:
+      :description: Request
+      :fields:
+        :owner_phone:
+          :description: Phone
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_country:
+          :description: Country/Region
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_phone_mobile:
+          :description: Mobile
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_title:
+          :description: Title
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_first_name:
+          :description: First Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_manager:
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_address:
+          :description: Address
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_company:
+          :description: Company
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_last_name:
+          :description: Last Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_manager_mail:
+          :description: E-Mail
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_city:
+          :description: City
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_department:
+          :description: Department
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_manager_phone:
+          :description: Phone
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_state:
+          :description: State
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_office:
+          :description: Office
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_zip:
+          :description: Zip code
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_email:
+          :description: E-Mail
+          :required_method: :validate_regex
+          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :request_notes:
+          :description: Notes
+          :required: false
+          :display: :edit
+          :data_type: :string
+      :display: :show
+      :field_order:
+    :purpose:
+      :description: Purpose
+      :fields:
+        :tag_ids:
+          :required_method: :validate_tags
+          :description: Tags
+          :required: false
+          :options:
+            :include: []
+            :order: []
+            :single_select: []
+            :exclude: []
+          :display: :edit
+          :required_tags: []
+          :data_type: :integer
+      :display: :show
+      :field_order:
+    :customize:
+      :description: Customize
+      :fields:
+        :credential_id:
+          :values_from:
+            :method: :allowed_credentials
+          :description: Cloud Credential
+          :required: false
+          :display: :edit
+          :data_type: :integer
+          :notes: Cloud Credential from [ Automation / Embedded Terraform / Credentials ]
+      :display: :show
+    :service:
+      :description: Catalog
+      :fields:
+        :src_configuration_script_id:
+          :values_from:
+            :method: :allowed_configuration_scripts
+          :description: Configuration Script
+          :required: true
+          :notes:
+          :display: :edit
+          :data_type: :integer
+          :notes_display: :show
+      :display: :show
+    :schedule:
+      :description: Schedule
+      :fields:
+        :schedule_type:
+          :values:
+            schedule: Schedule
+            immediately: Immediately on Approval
+          :description: When to Provision
+          :required: false
+          :display: :edit
+          :default: immediately
+          :data_type: :string
+        :schedule_time:
+          :values_from:
+            :options:
+              :offset: 1.day
+            :method: :default_schedule_time
+          :description: Provision on
+          :required: false
+          :display: :edit
+          :data_type: :time
+      :display: :show
+  :dialog_order:
+  - :requester
+  - :purpose
+  - :service
+  - :customize
+  - :schedule

--- a/content/miq_dialogs/miq_provision_configuration_script_embedded_terraform_dialogs.yaml
+++ b/content/miq_dialogs/miq_provision_configuration_script_embedded_terraform_dialogs.yaml
@@ -155,6 +155,15 @@
           :required: false
           :display: :edit
           :data_type: :integer
+        :credential_type:
+          :values_from:
+            :method: :allowed_credential_types
+          :description: Credential Type
+          :required: false
+          :display: :edit
+          :data_type: :string
+          :auto_select_single: false
+          :notes: Select the type of cloud credential to use
         :credential_id:
           :values_from:
             :method: :allowed_credentials
@@ -162,6 +171,7 @@
           :required: false
           :display: :edit
           :data_type: :integer
+          :auto_select_single: false
           :notes: Cloud Credential from [ Automation / Embedded Terraform / Credentials ]
       :display: :show
     :service:

--- a/spec/factories/miq_dialog.rb
+++ b/spec/factories/miq_dialog.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :miq_provision_configuration_script_embedded_terraform_dialogs, :parent => :miq_dialog do
+    name        { "miq_provision_configuration_script_embedded_terraform_dialogs" }
+    dialog_type { "MiqProvisionConfigurationScriptWorkflow" }
+  end
+end

--- a/spec/factories/service.rb
+++ b/spec/factories/service.rb
@@ -4,4 +4,9 @@ FactoryBot.define do
           :parent => :service do
     options { {} }
   end
+  factory :service_embedded_terraform,
+          :class  => "ServiceEmbeddedTerraform",
+          :parent => :service do
+    options { {} }
+  end
 end

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/provision_spec.rb
@@ -4,7 +4,7 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
   let(:ems)          { FactoryBot.create(:embedded_automation_manager_terraform, :zone => zone) }
   let(:terraform_template) { FactoryBot.create(:terraform_template, :manager => ems) }
   let(:configuration_script) { FactoryBot.create(:configuration_script_embedded_terraform, :manager => ems, :parent => terraform_template) }
-  let(:env_vars) { {} }
+  let!(:service) { FactoryBot.create(:service_embedded_terraform) }
   let(:miq_request)  { FactoryBot.create(:miq_provision_request, :requester => admin, :source => configuration_script) }
   let(:options)      { {:source => [terraform_template.id, terraform_template.name]} }
   let(:miq_task_state) { MiqTask::STATE_ACTIVE }
@@ -25,6 +25,7 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
       :phase        => phase
     )
   end
+  let(:stack_options) { {:action => ResourceAction::PROVISION, :input_vars => {}, :credentials => []} }
 
   it ".my_role" do
     expect(subject.my_role).to eq("ems_operations")
@@ -36,7 +37,8 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
 
   describe ".run_provision" do
     before do
-      allow(described_class.module_parent::Stack).to receive(:create_stack).with(terraform_template).and_return(new_stack)
+      allow(Service).to receive(:find_by).and_return(service)
+      allow(described_class.module_parent::Stack).to receive(:create_stack).with(terraform_template, stack_options).and_return(new_stack)
     end
 
     it "calls create_stack" do

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/provision_spec.rb
@@ -6,7 +6,7 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
   let(:configuration_script) { FactoryBot.create(:configuration_script_embedded_terraform, :manager => ems, :parent => terraform_template) }
   let!(:service) { FactoryBot.create(:service_embedded_terraform) }
   let(:miq_request)  { FactoryBot.create(:miq_provision_request, :requester => admin, :source => configuration_script) }
-  let(:options)      { {:source => [terraform_template.id, terraform_template.name]} }
+  let(:options)      { {:source => [terraform_template.id, terraform_template.name], :service_guid => service.guid} }
   let(:miq_task_state) { MiqTask::STATE_ACTIVE }
   let(:miq_task_status) { MiqTask::STATUS_OK }
   let(:miq_task) { FactoryBot.create(:miq_task, :state => miq_task_state, :status => miq_task_status) }
@@ -127,6 +127,68 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
           :state  => "finished",
           :status => "Error"
         )
+      end
+    end
+  end
+
+  describe "#update_stack_resource_data!" do
+    let(:phase) { "post_provision" }
+    let(:job) { FactoryBot.create(:embedded_terraform_job, :options => job_options) }
+    let(:job_options) { {:terraform_stack_id => "c247b890-4af1-11f1-bd0c-0f4596b0f2c6", :terraform_stack_job_id => "1"} }
+    let(:service_resource) { FactoryBot.create(:service_resource, :service => service, :resource => new_stack) }
+
+    before do
+      subject.phase_context[:stack_id] = new_stack.id
+      new_stack.update(:miq_task => miq_task)
+      miq_task.update(:job => job)
+      allow(new_stack).to receive(:raw_status).and_return(new_stack.class.status_class.new(miq_task))
+    end
+
+    context "when all data is present" do
+      before { service_resource }
+
+      it "successfully updates service_resources with terraform_runner_stack_id and terraform_runner_stack_job_id" do
+        subject.send(:update_stack_resource_data!)
+
+        service_resource.reload
+        expect(service_resource.options["terraform_runner_stack_id"]).to eq(job_options[:terraform_stack_id])
+        expect(service_resource.options["terraform_runner_stack_job_id"]).to eq(job_options[:terraform_stack_job_id])
+      end
+    end
+
+    context "when stack is missing" do
+      it "handles missing stack gracefully" do
+        allow(subject).to receive(:stack).and_return(nil)
+
+        expect { subject.send(:update_stack_resource_data!) }.not_to raise_error
+      end
+    end
+
+    context "when terraform_runner_stack_id is missing" do
+      let(:job_options) { {} }
+
+      before { service_resource }
+
+      it "handles missing terraform_runner_stack_id gracefully" do
+        expect { subject.send(:update_stack_resource_data!) }.not_to raise_error
+
+        service_resource.reload
+        expect(service_resource.options["terraform_runner_stack_id"]).to be_nil
+      end
+    end
+
+    context "when stack_resource is missing" do
+      it "handles missing stack_resource gracefully" do
+        expect { subject.send(:update_stack_resource_data!) }.not_to raise_error
+      end
+    end
+    context "when stack_resource update fails" do
+      before { service_resource }
+
+      it "logs a warning when update returns false" do
+        allow_any_instance_of(ServiceResource).to receive(:update).and_return(false)
+        expect($embedded_terraform_log).to receive(:warn).with("Failed to update stack resource options")
+        subject.send(:update_stack_resource_data!)
       end
     end
   end

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/provision_spec.rb
@@ -186,8 +186,8 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
       before { service_resource }
 
       it "logs a warning when update returns false" do
-        allow_any_instance_of(ServiceResource).to receive(:update).and_return(false)
-        expect($embedded_terraform_log).to receive(:warn).with("Failed to update stack resource options")
+        allow_any_instance_of(ServiceResource).to receive(:update!).and_raise("ERROR")
+        expect($embedded_terraform_log).to receive(:warn).with("Failed to update stack resource options: ERROR")
         subject.send(:update_stack_resource_data!)
       end
     end

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/provision_spec.rb
@@ -135,7 +135,7 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
     let(:phase) { "post_provision" }
     let(:job) { FactoryBot.create(:embedded_terraform_job, :options => job_options) }
     let(:job_options) { {:terraform_stack_id => "c247b890-4af1-11f1-bd0c-0f4596b0f2c6", :terraform_stack_job_id => "1"} }
-    let(:service_resource) { FactoryBot.create(:service_resource, :service => service, :resource => new_stack) }
+    let!(:service_resource) { FactoryBot.create(:service_resource, :service => service, :resource => new_stack) }
 
     before do
       subject.phase_context[:stack_id] = new_stack.id
@@ -145,8 +145,6 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
     end
 
     context "when all data is present" do
-      before { service_resource }
-
       it "successfully updates service_resources with terraform_runner_stack_id and terraform_runner_stack_job_id" do
         subject.send(:update_stack_resource_data!)
 
@@ -167,8 +165,6 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
     context "when terraform_runner_stack_id is missing" do
       let(:job_options) { {} }
 
-      before { service_resource }
-
       it "handles missing terraform_runner_stack_id gracefully" do
         expect { subject.send(:update_stack_resource_data!) }.not_to raise_error
 
@@ -182,9 +178,8 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
         expect { subject.send(:update_stack_resource_data!) }.not_to raise_error
       end
     end
-    context "when stack_resource update fails" do
-      before { service_resource }
 
+    context "when stack_resource update fails" do
       it "logs a warning when update returns false" do
         allow_any_instance_of(ServiceResource).to receive(:update!).and_raise("ERROR")
         expect($embedded_terraform_log).to receive(:warn).with("Failed to update stack resource options: ERROR")

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/provision_spec.rb
@@ -55,7 +55,7 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
 
     it "queues check_provisioned" do
       subject.instance_variable_set(:@stack, new_stack)
-      allow(new_stack).to receive(:raw_status).and_return(new_stack.class.status_class.new(miq_task))
+      allow(new_stack).to receive(:raw_status).and_return(new_stack.class.status_class.new(new_stack))
 
       subject.run_provision
 
@@ -79,7 +79,7 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
     let(:phase) { "check_provisioned" }
 
     before do
-      allow(new_stack).to receive(:raw_status).and_return(new_stack.class.status_class.new(miq_task))
+      allow(new_stack).to receive(:raw_status).and_return(new_stack.class.status_class.new(new_stack))
       subject.instance_variable_set(:@stack, new_stack)
       subject.phase_context[:stack_id] = new_stack.id
     end
@@ -141,7 +141,7 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
       subject.phase_context[:stack_id] = new_stack.id
       new_stack.update(:miq_task => miq_task)
       miq_task.update(:job => job)
-      allow(new_stack).to receive(:raw_status).and_return(new_stack.class.status_class.new(miq_task))
+      allow(new_stack).to receive(:raw_status).and_return(new_stack.class.status_class.new(new_stack))
     end
 
     context "when all data is present" do

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/provision_workflow_spec.rb
@@ -1,7 +1,7 @@
 describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::ProvisionWorkflow do
   let(:admin)        { FactoryBot.create(:user_with_group) }
   let(:manager)      { FactoryBot.create(:embedded_automation_manager_terraform) }
-  let(:dialog)       { FactoryBot.create(:miq_provision_configuration_script_dialog) }
+  let(:dialog)       { FactoryBot.create(:miq_provision_configuration_script_embedded_terraform_dialogs) }
 
   describe "#allowed_configuration_scripts" do
     context "with no configuration_scripts" do

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/provision_workflow_spec.rb
@@ -23,4 +23,159 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::ProvisionWor
       end
     end
   end
+
+  describe "#allowed_credentials" do
+    context "with no credentials" do
+      it "returns an empty hash" do
+        workflow = described_class.new({:provision_dialog_name => dialog.name}, admin.userid)
+        expect(workflow.allowed_credentials).to eq({})
+      end
+    end
+
+    context "with multiple credentials and no credential_type filter" do
+      let!(:amazon_cred)  { FactoryBot.create(:embedded_terraform_amazon_credential, :name => "AWS Prod") }
+      let!(:azure_cred)   { FactoryBot.create(:embedded_terraform_azure_credential, :name => "Azure Dev") }
+      let!(:vsphere_cred) { FactoryBot.create(:embedded_terraform_vsphere_credential, :name => "vSphere Test") }
+
+      it "returns all TemplateCredential instances" do
+        workflow = described_class.new({:provision_dialog_name => dialog.name}, admin.userid)
+        allowed = workflow.allowed_credentials
+
+        expect(allowed).to be_a(Hash)
+        expect(allowed.keys).to contain_exactly(amazon_cred.id, azure_cred.id, vsphere_cred.id)
+        expect(allowed[amazon_cred.id]).to eq("AWS Prod")
+        expect(allowed[azure_cred.id]).to eq("Azure Dev")
+        expect(allowed[vsphere_cred.id]).to eq("vSphere Test")
+      end
+    end
+
+    context "with credential_type filter for AmazonCredential" do
+      let!(:amazon_cred)  { FactoryBot.create(:embedded_terraform_amazon_credential, :name => "AWS Prod") }
+      let!(:azure_cred)   { FactoryBot.create(:embedded_terraform_azure_credential, :name => "Azure Dev") }
+      let!(:vsphere_cred) { FactoryBot.create(:embedded_terraform_vsphere_credential, :name => "vSphere Test") }
+
+      it "returns only Amazon credentials" do
+        workflow = described_class.new({:provision_dialog_name => dialog.name}, admin.userid)
+        workflow.values[:credential_type] = ["ManageIQ::Providers::EmbeddedTerraform::AutomationManager::AmazonCredential", nil]
+        allowed = workflow.allowed_credentials
+
+        expect(allowed).to be_a(Hash)
+        expect(allowed.keys).to contain_exactly(amazon_cred.id)
+        expect(allowed[amazon_cred.id]).to eq("AWS Prod")
+      end
+    end
+
+    context "with credential_type filter for AzureCredential" do
+      let!(:amazon_cred)  { FactoryBot.create(:embedded_terraform_amazon_credential, :name => "AWS Prod") }
+      let!(:azure_cred)   { FactoryBot.create(:embedded_terraform_azure_credential, :name => "Azure Dev") }
+      let!(:vsphere_cred) { FactoryBot.create(:embedded_terraform_vsphere_credential, :name => "vSphere Test") }
+
+      it "returns only Azure credentials" do
+        workflow = described_class.new({:provision_dialog_name => dialog.name}, admin.userid)
+        workflow.values[:credential_type] = ["ManageIQ::Providers::EmbeddedTerraform::AutomationManager::AzureCredential", nil]
+        allowed = workflow.allowed_credentials
+
+        expect(allowed).to be_a(Hash)
+        expect(allowed.keys).to contain_exactly(azure_cred.id)
+        expect(allowed[azure_cred.id]).to eq("Azure Dev")
+      end
+    end
+
+    context "with invalid credential_type" do
+      let!(:amazon_cred)  { FactoryBot.create(:embedded_terraform_amazon_credential, :name => "AWS Prod") }
+      let!(:azure_cred)   { FactoryBot.create(:embedded_terraform_azure_credential, :name => "Azure Dev") }
+
+      it "falls back to all TemplateCredentials" do
+        workflow = described_class.new({:provision_dialog_name => dialog.name}, admin.userid)
+        workflow.values[:credential_type] = ["InvalidClassName", nil]
+        allowed = workflow.allowed_credentials
+
+        expect(allowed).to be_a(Hash)
+        expect(allowed.keys).to contain_exactly(amazon_cred.id, azure_cred.id)
+      end
+    end
+  end
+
+  describe "#allowed_credential_types" do
+    context "with no credential_id specified" do
+      it "returns all TemplateCredential descendant types with API_OPTIONS" do
+        workflow = described_class.new({:provision_dialog_name => dialog.name}, admin.userid)
+        allowed = workflow.allowed_credential_types
+
+        expect(allowed).to be_a(Hash)
+        expect(allowed.keys).to include(
+          "ManageIQ::Providers::EmbeddedTerraform::AutomationManager::AmazonCredential",
+          "ManageIQ::Providers::EmbeddedTerraform::AutomationManager::AzureCredential",
+          "ManageIQ::Providers::EmbeddedTerraform::AutomationManager::VsphereCredential",
+          "ManageIQ::Providers::EmbeddedTerraform::AutomationManager::GoogleCredential",
+          "ManageIQ::Providers::EmbeddedTerraform::AutomationManager::OpenstackCredential",
+          "ManageIQ::Providers::EmbeddedTerraform::AutomationManager::IbmCloudCredential",
+          "ManageIQ::Providers::EmbeddedTerraform::AutomationManager::IbmClassicInfrastructureCredential"
+        )
+      end
+
+      it "returns correct labels for each credential type" do
+        workflow = described_class.new({:provision_dialog_name => dialog.name}, admin.userid)
+        allowed = workflow.allowed_credential_types
+
+        expect(allowed["ManageIQ::Providers::EmbeddedTerraform::AutomationManager::AmazonCredential"]).to eq("Amazon")
+        expect(allowed["ManageIQ::Providers::EmbeddedTerraform::AutomationManager::AzureCredential"]).to eq("Azure")
+      end
+    end
+
+    context "with credential_id for AmazonCredential" do
+      let!(:amazon_cred) { FactoryBot.create(:embedded_terraform_amazon_credential, :name => "AWS Prod") }
+
+      it "returns only the AmazonCredential type" do
+        workflow = described_class.new({:provision_dialog_name => dialog.name}, admin.userid)
+        workflow.values[:credential_id] = [amazon_cred.id, nil]
+        allowed = workflow.allowed_credential_types
+
+        expect(allowed).to be_a(Hash)
+        expect(allowed.keys).to contain_exactly("ManageIQ::Providers::EmbeddedTerraform::AutomationManager::AmazonCredential")
+        expect(allowed["ManageIQ::Providers::EmbeddedTerraform::AutomationManager::AmazonCredential"]).to eq("Amazon")
+      end
+    end
+
+    context "with credential_id for AzureCredential" do
+      let!(:azure_cred) { FactoryBot.create(:embedded_terraform_azure_credential, :name => "Azure Dev") }
+
+      it "returns only the AzureCredential type" do
+        workflow = described_class.new({:provision_dialog_name => dialog.name}, admin.userid)
+        workflow.values[:credential_id] = [azure_cred.id, nil]
+        allowed = workflow.allowed_credential_types
+
+        expect(allowed).to be_a(Hash)
+        expect(allowed.keys).to contain_exactly("ManageIQ::Providers::EmbeddedTerraform::AutomationManager::AzureCredential")
+        expect(allowed["ManageIQ::Providers::EmbeddedTerraform::AutomationManager::AzureCredential"]).to eq("Azure")
+      end
+    end
+
+    context "with credential_id for VsphereCredential" do
+      let!(:vsphere_cred) { FactoryBot.create(:embedded_terraform_vsphere_credential, :name => "vSphere Test") }
+
+      it "returns only the VsphereCredential type" do
+        workflow = described_class.new({:provision_dialog_name => dialog.name}, admin.userid)
+        workflow.values[:credential_id] = [vsphere_cred.id, nil]
+        allowed = workflow.allowed_credential_types
+
+        expect(allowed).to be_a(Hash)
+        expect(allowed.keys).to contain_exactly("ManageIQ::Providers::EmbeddedTerraform::AutomationManager::VsphereCredential")
+      end
+    end
+
+    context "with invalid credential_id" do
+      it "falls back to all TemplateCredential descendants" do
+        workflow = described_class.new({:provision_dialog_name => dialog.name}, admin.userid)
+        workflow.values[:credential_id] = [99_999, nil]
+        allowed = workflow.allowed_credential_types
+
+        expect(allowed).to be_a(Hash)
+        expect(allowed.keys).to include(
+          "ManageIQ::Providers::EmbeddedTerraform::AutomationManager::AmazonCredential",
+          "ManageIQ::Providers::EmbeddedTerraform::AutomationManager::AzureCredential"
+        )
+      end
+    end
+  end
 end

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/stack_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/stack_spec.rb
@@ -172,6 +172,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack 
         end
       end
     end
+
     describe "#raw_delete_stack" do
       let(:stack) { FactoryBot.create(:terraform_stack) }
       let(:terraform_template) { FactoryBot.create(:terraform_template) }

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/stack_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/stack_spec.rb
@@ -172,5 +172,126 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack 
         end
       end
     end
+    describe "#raw_delete_stack" do
+      let(:stack) { FactoryBot.create(:terraform_stack) }
+      let(:terraform_template) { FactoryBot.create(:terraform_template) }
+      let(:delete_job) { FactoryBot.create(:embedded_terraform_job) }
+
+      before do
+        allow(stack).to receive(:configuration_script_payload).and_return(terraform_template)
+      end
+
+      context "when service_resource is nil" do
+        before do
+          allow(stack).to receive(:service_resource).and_return(nil)
+        end
+
+        it "raises an error" do
+          expect { stack.raw_delete_stack }.to raise_error(
+            MiqException::Error,
+            /Cannot delete stack, service_resource not found for stack:/
+          )
+        end
+      end
+
+      context "when service_resource.options is blank" do
+        let(:service_resource) { double("ServiceResource", :options => nil) }
+
+        before do
+          allow(stack).to receive(:service_resource).and_return(service_resource)
+        end
+
+        it "raises an error" do
+          expect { stack.raw_delete_stack }.to raise_error(
+            MiqException::Error,
+            /Cannot delete stack, service_resource.options is empty for stack:/
+          )
+        end
+      end
+
+      context "when terraform_runner_stack_id is missing" do
+        let(:service_resource) { double("ServiceResource", :options => {"other_key" => "value"}) }
+
+        before do
+          allow(stack).to receive(:service_resource).and_return(service_resource)
+        end
+
+        it "raises an error" do
+          expect { stack.raw_delete_stack }.to raise_error(
+            MiqException::MiqOrchestrationProvisionError,
+            /Cannot delete stack, did not find terraform_runner_stack_id for stack:/
+          )
+        end
+      end
+
+      context "when configuration_script_payload is nil" do
+        let(:service_resource) do
+          double("ServiceResource", :options => {"terraform_runner_stack_id" => "stack-123"})
+        end
+
+        before do
+          allow(stack).to receive(:service_resource).and_return(service_resource)
+          allow(stack).to receive(:configuration_script_payload).and_return(nil)
+        end
+
+        it "raises an error" do
+          expect { stack.raw_delete_stack }.to raise_error(
+            MiqException::Error,
+            /Cannot delete stack, configuration script payload not found for stack:/
+          )
+        end
+      end
+
+      context "when all required data is present" do
+        let(:service_resource) do
+          double("ServiceResource", :options => {
+                   "terraform_runner_stack_id" => "stack-123",
+                   "input_vars"                => {"key" => "value"},
+                   "credentials"               => ["999"]
+                 })
+        end
+
+        before do
+          allow(stack).to receive(:service_resource).and_return(service_resource)
+          allow(terraform_template).to receive(:run).and_return(delete_job)
+        end
+
+        it "creates a delete job with correct options" do
+          expected_options = {
+            "input_vars"        => {"key" => "value"},
+            "credentials"       => ["999"],
+            :action             => ResourceAction::RETIREMENT,
+            :terraform_stack_id => "stack-123"
+          }
+
+          expect(terraform_template).to receive(:run).with(expected_options).and_return(delete_job)
+          result = stack.raw_delete_stack
+          expect(result).to eq(delete_job)
+        end
+
+        it "returns the delete job" do
+          result = stack.raw_delete_stack
+          expect(result).to eq(delete_job)
+        end
+      end
+
+      context "when an unexpected error occurs" do
+        let(:service_resource) do
+          double("ServiceResource", :options => {"terraform_runner_stack_id" => "stack-123"})
+        end
+
+        before do
+          allow(stack).to receive(:service_resource).and_return(service_resource)
+          allow(terraform_template).to receive(:run).and_raise(StandardError, "Unexpected error")
+        end
+
+        it "raises MiqOrchestrationProvisionError" do
+          expect { stack.raw_delete_stack }.to raise_error(
+            MiqException::MiqOrchestrationProvisionError,
+            /Unexpected error/
+          )
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Depends on:

- [x] https://github.com/ManageIQ/manageiq-ui-classic/pull/9949
- [x] https://github.com/ManageIQ/manageiq-ui-classic/pull/9950

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
