### PR TITLE
Update jwt to 3.2.0 for CVE-2026-45363

### DIFF
--- a/manageiq-providers-embedded_terraform.gemspec
+++ b/manageiq-providers-embedded_terraform.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "jwt", "~>2.2"
+  spec.add_dependency "jwt", "~> 3.2"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov",  ">= 0.21.2"


### PR DESCRIPTION
@agrare Please review.

Here's the information about upgrading to 3.x: https://github.com/jwt/ruby-jwt/blob/main/UPGRADING.md, however I don't _think_ it affects anything in this repo.

The bigger problem is that the oci gem also depends on 2.x, so we;re going to have to find a way to upgrade that one.

```
Could not find compatible versions

Because every version of manageiq-providers-oracle_cloud depends on oci ~> 2.22
  and oci >= 2.0.6 depends on jwt ~> 2.1,
  every version of manageiq-providers-oracle_cloud requires jwt ~> 2.1.
And because every version of manageiq-providers-embedded_terraform depends on jwt ~> 3.2,
  every version of manageiq-providers-oracle_cloud is incompatible with manageiq-providers-embedded_terraform >= 0.
So, because Gemfile depends on manageiq-providers-embedded_terraform >= 0
  and Gemfile depends on manageiq-providers-oracle_cloud >= 0,
  version solving has failed.
```