### PR TITLE
[WIP] Handle Terraform Runner Unavailability during migration or restarts(OOM)

### DIFF
--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
@@ -27,14 +27,20 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
 
   def poll_execute
     if Terraform::Runner.available?
+      options.delete(:runner_wait_started_at)
+      save!
       signal(:execute)
     else
-      $embedded_terraform_log.info("Terraform::Runner service is not available, requeueing poll_execute for Job#{id}")
-      queue_signal(:poll_execute, :deliver_on => Time.now.utc + poll_interval)
+      requeue_or_abort_on_runner_unavailable(:poll_execute)
     end
   end
 
   def execute
+    unless Terraform::Runner.available?
+      requeue_or_abort_on_runner_unavailable(:poll_execute)
+      return
+    end
+
     template_path = File.join(options[:git_checkout_tempdir], template_relative_path)
     credentials   = Authentication.where(:id => options[:credentials])
     action        = options[:action]
@@ -66,6 +72,9 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
     save!
 
     queue_poll_runner
+  rescue Terraform::Runner::TemporarilyUnavailable => e
+    $embedded_terraform_log.warn("Terraform::Runner became unavailable during execute for Job#{id}: #{e.message}")
+    requeue_or_abort_on_runner_unavailable(:poll_execute)
   end
 
   def poll_runner
@@ -74,12 +83,16 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
         $embedded_terraform_log.debug("Stack is still running, requeueing polling for Job#{id}")
         queue_poll_runner
       else
+        options.delete(:runner_wait_started_at)
+        save!
         signal(:post_execute)
       end
     else
-      $embedded_terraform_log.info("Terraform::Runner service is not available, requeueing polling for Job#{id}")
-      queue_poll_runner
+      requeue_or_abort_on_runner_unavailable(:poll_runner)
     end
+  rescue Terraform::Runner::TemporarilyUnavailable => e
+    $embedded_terraform_log.warn("Terraform::Runner became unavailable during poll_runner for Job#{id}: #{e.message}")
+    requeue_or_abort_on_runner_unavailable(:poll_runner)
   end
 
   def post_execute
@@ -134,6 +147,10 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
     options.fetch(:poll_interval, 30.seconds).to_i
   end
 
+  def max_runner_wait_time
+    Terraform::Runner.availability_max_wait_time
+  end
+
   private
 
   def template
@@ -165,6 +182,20 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
 
   def queue_poll_runner
     queue_signal(:poll_runner, :deliver_on => Time.now.utc + poll_interval)
+  end
+
+  def requeue_or_abort_on_runner_unavailable(signal_name)
+    options[:runner_wait_started_at] ||= Time.now.utc
+    save!
+
+    elapsed = Time.now.utc - options[:runner_wait_started_at]
+    if elapsed >= max_runner_wait_time
+      $embedded_terraform_log.error("Terraform::Runner unavailable for #{elapsed.to_i}s (max #{max_runner_wait_time}s), aborting Job#{id}")
+      abort_job("Terraform runner unavailable for too long", "error")
+    else
+      $embedded_terraform_log.info("Terraform::Runner not available, requeueing #{signal_name} for Job#{id} (waited #{elapsed.to_i}s/#{max_runner_wait_time}s)")
+      queue_signal(signal_name, :deliver_on => Time.now.utc + poll_interval)
+    end
   end
 
   def checkout_git_repository

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
@@ -22,13 +22,15 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
 
   def pre_execute
     checkout_git_repository
+    queue_signal(:poll_execute)
+  end
 
+  def poll_execute
     if Terraform::Runner.available?
       signal(:execute)
     else
-      delay = 10.seconds # poll_interval
-      $embedded_terraform_log.debug("Terraform::Runner service is not available, requeueing job pre_execute with delay: #{delay}")
-      queue_signal(:pre_execute, :deliver_on => Time.now.utc + delay)
+      $embedded_terraform_log.info("Terraform::Runner service is not available, requeueing poll_execute")
+      queue_signal(:poll_execute, :deliver_on => Time.now.utc + poll_interval)
     end
   end
 
@@ -75,7 +77,7 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
         signal(:post_execute)
       end
     else
-      $embedded_terraform_log.debug("Terraform::Runner service is not available, requeueing polling")
+      $embedded_terraform_log.info("Terraform::Runner service is not available, requeueing polling")
       queue_poll_runner
     end
   end
@@ -117,6 +119,7 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
       :initializing => {'initialize'       => 'waiting_to_start'},
       :start        => {'waiting_to_start' => 'pre_execute'},
       :pre_execute  => {'pre_execute'      => 'execute'},
+      :poll_execute => {'execute'          => 'execute'},
       :execute      => {'execute'          => 'running'},
       :poll_runner  => {'running'          => 'running'},
       :post_execute => {'running'          => 'post_execute'},
@@ -128,7 +131,7 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
   end
 
   def poll_interval
-    options.fetch(:poll_interval, 1.minute).to_i
+    options.fetch(:poll_interval, 30.seconds).to_i
   end
 
   private

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
@@ -22,7 +22,14 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
 
   def pre_execute
     checkout_git_repository
-    signal(:execute)
+
+    if Terraform::Runner.available?
+      signal(:execute)
+    else
+      delay = 10.seconds # poll_interval
+      $embedded_terraform_log.debug("Terraform::Runner service is not available, requeueing job pre_execute with delay: #{delay}")
+      queue_signal(:pre_execute, :deliver_on => Time.now.utc + delay)
+    end
   end
 
   def execute
@@ -60,10 +67,16 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
   end
 
   def poll_runner
-    if running?
-      queue_poll_runner
+    if Terraform::Runner.available?
+      if running?
+        $embedded_terraform_log.debug("Stack is still running, requeueing polling")
+        queue_poll_runner
+      else
+        signal(:post_execute)
+      end
     else
-      signal(:post_execute)
+      $embedded_terraform_log.debug("Terraform::Runner service is not available, requeueing polling")
+      queue_poll_runner
     end
   end
 

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
@@ -29,7 +29,7 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
     if Terraform::Runner.available?
       signal(:execute)
     else
-      $embedded_terraform_log.info("Terraform::Runner service is not available, requeueing poll_execute")
+      $embedded_terraform_log.info("Terraform::Runner service is not available, requeueing poll_execute for Job#{id}")
       queue_signal(:poll_execute, :deliver_on => Time.now.utc + poll_interval)
     end
   end
@@ -71,13 +71,13 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
   def poll_runner
     if Terraform::Runner.available?
       if running?
-        $embedded_terraform_log.debug("Stack is still running, requeueing polling")
+        $embedded_terraform_log.debug("Stack is still running, requeueing polling for Job#{id}")
         queue_poll_runner
       else
         signal(:post_execute)
       end
     else
-      $embedded_terraform_log.info("Terraform::Runner service is not available, requeueing polling")
+      $embedded_terraform_log.info("Terraform::Runner service is not available, requeueing polling for Job#{id}")
       queue_poll_runner
     end
   end

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/job.rb
@@ -27,8 +27,7 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
 
   def poll_execute
     if Terraform::Runner.available?
-      options.delete(:runner_wait_started_at)
-      save!
+      remove_runner_wait_started_at!
       signal(:execute)
     else
       requeue_or_abort_on_runner_unavailable(:poll_execute)
@@ -79,12 +78,11 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
 
   def poll_runner
     if Terraform::Runner.available?
+      remove_runner_wait_started_at!
       if running?
         $embedded_terraform_log.debug("Stack is still running, requeueing polling for Job#{id}")
         queue_poll_runner
       else
-        options.delete(:runner_wait_started_at)
-        save!
         signal(:post_execute)
       end
     else
@@ -182,6 +180,11 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job < Job
 
   def queue_poll_runner
     queue_signal(:poll_runner, :deliver_on => Time.now.utc + poll_interval)
+  end
+
+  def remove_runner_wait_started_at!
+    options.delete(:runner_wait_started_at)
+    save!
   end
 
   def requeue_or_abort_on_runner_unavailable(signal_name)

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/provision/state_machine.rb
@@ -1,14 +1,20 @@
 module ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision::StateMachine
   def run_provision
     if Terraform::Runner.available?
+      phase_context.delete(:runner_wait_started_at)
+      save!
       signal :provision
     else
-      $embedded_terraform_log.debug("Terraform::Runner service is not available, requeueing provision")
-      requeue_phase
+      requeue_or_abort_on_runner_unavailable
     end
   end
 
   def provision
+    unless Terraform::Runner.available?
+      requeue_or_abort_on_runner_unavailable
+      return
+    end
+
     stack_opts = service.stack_opts(ResourceAction::PROVISION, options)
     stack = stack_klass.create_stack(source.terraform_template, stack_opts.dup)
 
@@ -18,6 +24,9 @@ module ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision::Sta
     save!
 
     signal :check_provisioned
+  rescue Terraform::Runner::TemporarilyUnavailable => e
+    $embedded_terraform_log.warn("Terraform::Runner became unavailable during provision: #{e.message}")
+    requeue_or_abort_on_runner_unavailable
   end
 
   def check_provisioned
@@ -34,7 +43,8 @@ module ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision::Sta
     if succeeded?
       signal :mark_as_completed
     else
-      raise MiqException::MiqProvisionError, "Failed to provision stack"
+      update_and_notify_parent(:state => "finished", :status => "Error", :message => "Failed to provision stack")
+      signal :finish
     end
   end
 
@@ -64,6 +74,25 @@ module ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision::Sta
   end
 
   private
+
+  def max_runner_wait_time
+    Terraform::Runner.availability_max_wait_time
+  end
+
+  def requeue_or_abort_on_runner_unavailable
+    phase_context[:runner_wait_started_at] ||= Time.now.utc
+    save!
+
+    elapsed = Time.now.utc - phase_context[:runner_wait_started_at]
+    if elapsed >= max_runner_wait_time
+      $embedded_terraform_log.error("Terraform::Runner unavailable for #{elapsed.to_i}s (max #{max_runner_wait_time}s), aborting provision")
+      update_and_notify_parent(:state => "finished", :status => "Error", :message => "Terraform runner unavailable for too long")
+      signal :finish
+    else
+      $embedded_terraform_log.info("Terraform::Runner not available, requeueing provision (waited #{elapsed.to_i}s/#{max_runner_wait_time}s)")
+      requeue_phase
+    end
+  end
 
   # Updates the service resource with terraform runner stack information
   # that will be used during retirement actions.

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/provision/state_machine.rb
@@ -1,6 +1,11 @@
 module ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision::StateMachine
   def run_provision
-    signal :provision
+    if Terraform::Runner.available?
+      signal :provision
+    else
+      $embedded_terraform_log.debug("Terraform::Runner service is not available, requeueing provision")
+      requeue_phase
+    end
   end
 
   def provision

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb
@@ -59,10 +59,11 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
 
   def delete_stack
     if Terraform::Runner.available?
+      options.delete(:runner_wait_started_at)
+      save!
       raw_delete_stack
     else
-      $embedded_terraform_log.debug("Terraform::Runner service is not available, requeueing delete_stack for Stack#{id}")
-      queue_delete_stack
+      requeue_or_fail_on_runner_unavailable
     end
   end
 
@@ -89,6 +90,9 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
     $embedded_terraform_log.debug("Delete job created : #{delete_job.id}")
 
     delete_job
+  rescue Terraform::Runner::TemporarilyUnavailable => e
+    $embedded_terraform_log.warn("Terraform::Runner became unavailable during raw_delete_stack for Stack#{id}: #{e.message}")
+    requeue_or_fail_on_runner_unavailable
   rescue => err
     handle_stack_operation_error("delete stack for stack:#{id}", err)
   end
@@ -197,6 +201,24 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
 
   def delay_interval
     options.fetch(:delay_interval, 30.seconds).to_i
+  end
+
+  def max_runner_wait_time
+    Terraform::Runner.availability_max_wait_time
+  end
+
+  def requeue_or_fail_on_runner_unavailable
+    options[:runner_wait_started_at] ||= Time.now.utc
+    save!
+
+    elapsed = Time.now.utc - options[:runner_wait_started_at]
+    if elapsed >= max_runner_wait_time
+      $embedded_terraform_log.error("Terraform::Runner unavailable for #{elapsed.to_i}s (max #{max_runner_wait_time}s), failing delete_stack for Stack#{id}")
+      raise MiqException::Error, "Terraform runner unavailable for too long, cannot delete stack:#{id}"
+    else
+      $embedded_terraform_log.info("Terraform::Runner not available, requeueing delete_stack for Stack#{id} (waited #{elapsed.to_i}s/#{max_runner_wait_time}s)")
+      queue_delete_stack
+    end
   end
 
   def terraform_runner_stack_data

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb
@@ -57,6 +57,15 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
     service.instance_of?(ServiceEmbeddedTerraform)
   end
 
+  def delete_stack
+    if Terraform::Runner.available?
+      raw_delete_stack
+    else
+      $embedded_terraform_log.debug("Terraform::Runner service is not available, requeueing delete_stack for Stack#{id}")
+      queue_delete_stack
+    end
+  end
+
   def raw_delete_stack
     raise MiqException::Error, "Cannot delete stack, service_resource not found for stack:#{id}" if service_resource.nil?
     raise MiqException::Error, "Cannot delete stack, service_resource.options is empty for stack:#{id}" if service_resource.options.blank?
@@ -106,6 +115,10 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
         save!
       end
     end
+  end
+
+  def queue_delete_stack
+    MiqQueue.put(:class_name => self.class.name, :instance_id => id, :method_name => "delete_stack", :role => "embedded_terraform", :deliver_on => Time.now.utc + delay_interval)
   end
 
   def queue_refresh
@@ -181,6 +194,10 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
   end
 
   private
+
+  def delay_interval
+    options.fetch(:delay_interval, 30.seconds).to_i
+  end
 
   def terraform_runner_stack_data
     if service_resource.present?

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb
@@ -59,8 +59,7 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
 
   def delete_stack
     if Terraform::Runner.available?
-      options.delete(:runner_wait_started_at)
-      save!
+      remove_runner_wait_started_at!
       raw_delete_stack
     else
       requeue_or_fail_on_runner_unavailable
@@ -201,6 +200,11 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
 
   def delay_interval
     options.fetch(:delay_interval, 30.seconds).to_i
+  end
+
+  def remove_runner_wait_started_at!
+    options.delete(:runner_wait_started_at)
+    save!
   end
 
   def max_runner_wait_time

--- a/lib/terraform/runner.rb
+++ b/lib/terraform/runner.rb
@@ -7,14 +7,17 @@ module Terraform
   class Runner
     class << self
       def available?
-        return true if defined?(@available) && @available == true
+        return @available if defined?(@available) && @available == true
 
-        # If not available, always fetch ready status from Terraform Runner service
-        response = terraform_runner_client.get('ready')
-        $embedded_terraform_log.debug("==== /ready : response.body: #{response.body}")
-        @available = response.status == 200 && JSON.parse(response.body)['status'] == 'UP'
-      rescue
-        @available = false
+        @available_mutex = Mutex.new unless defined?(@available_mutex)
+        @available_mutex.synchronize do
+          # Fetch ready status from Terraform Runner service
+          response = terraform_runner_client.get('ready')
+          $embedded_terraform_log.debug("Terraform runner ready check response: #{response.body}")
+          @available = response.status == 200 && JSON.parse(response.body)['status'] == 'UP'
+        rescue
+          @available = false
+        end
       end
 
       # Run TerraformRunner Stack actions with a Terraform template.
@@ -181,7 +184,7 @@ module Terraform
           if http_response.status == 503
             $embedded_terraform_log.warn("Received 503 error from terraform runner, and migration is active, waiting for availability...")
             # Reset cache and to check availability again
-            @available = false
+            @available_mutex.synchronize { @available = false }
             wait_for_runner_availability!
 
             http_response = terraform_runner_client.post(
@@ -192,7 +195,7 @@ module Terraform
         rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
           $embedded_terraform_log.warn("Server not reachable: #{e.message}, waiting for availability...")
           # Reset cache and to check availability again
-          @available = false
+          @available_mutex.synchronize { @available = false }
           wait_for_runner_availability!
 
           http_response = terraform_runner_client.post(
@@ -226,10 +229,8 @@ module Terraform
         until elapsed_time >= max_wait_time
           sleep(check_interval)
           elapsed_time += check_interval
-          $embedded_terraform_log.info("Waiting for terraform runner availability... (#{elapsed_time}/#{max_wait_time} seconds)")
 
-          # Reset cache and check availability
-          @available = false
+          $embedded_terraform_log.info("Waiting for terraform runner availability... (#{elapsed_time}/#{max_wait_time} seconds)")
           break if available?
         end
 

--- a/lib/terraform/runner.rb
+++ b/lib/terraform/runner.rb
@@ -7,8 +7,9 @@ module Terraform
   class Runner
     class << self
       def available?
-        return true if @available
+        return true if defined?(@available) && @available == true
 
+        # If not available, always fetch ready status from Terraform Runner service
         response = terraform_runner_client.get('ready')
         $embedded_terraform_log.debug("==== /ready : response.body: #{response.body}")
         @available = response.status == 200 && JSON.parse(response.body)['status'] == 'UP'
@@ -86,6 +87,7 @@ module Terraform
       #
       # @return [Terraform::Runner::Response] Response object with result of terraform run
       def retrieve_stack(stack_id, stack_job_id = nil)
+        $embedded_terraform_log.debug("Retrieve terraform runner stack: #{stack_id}/#{stack_job_id}")
         run_terraform_runner_stack_api(
           Request.new(
             ActionType::RETRIEVE,
@@ -169,10 +171,35 @@ module Terraform
 
         action_endpoint = ActionType.action_endpoint(request.action_type)
 
-        http_response = terraform_runner_client.post(
-          action_endpoint,
-          *request.build_json_post_arguments
-        )
+        begin
+          http_response = terraform_runner_client.post(
+            action_endpoint,
+            *request.build_json_post_arguments
+          )
+
+          # If we get a 503 error, then wait for runner availability and retry
+          if http_response.status == 503
+            $embedded_terraform_log.warn("Received 503 error from terraform runner, and migration is active, waiting for availability...")
+            # Reset cache and to check availability again
+            @available = false
+            wait_for_runner_availability!
+
+            http_response = terraform_runner_client.post(
+              action_endpoint,
+              *request.build_json_post_arguments
+            )
+          end
+        rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
+          $embedded_terraform_log.warn("Server not reachable: #{e.message}, waiting for availability...")
+          # Reset cache and to check availability again
+          @available = false
+          wait_for_runner_availability!
+
+          http_response = terraform_runner_client.post(
+            action_endpoint,
+            *request.build_json_post_arguments
+          )
+        end
 
         if request.action_type == ActionType::CREATE
           $embedded_terraform_log.info("terraform-runnner #{action_endpoint} for #{request.options["name"]} is running ...")
@@ -190,7 +217,7 @@ module Terraform
       def wait_for_runner_availability!
         return if available?
 
-        $embedded_terraform_log.info("Terraform runner is not available, waiting for up to #{runner_availability_wait_time_in_secs} seconds...")
+        $embedded_terraform_log.warn("Terraform runner is not available, waiting for up to #{runner_availability_wait_time_in_secs} seconds...")
 
         max_wait_time = runner_availability_wait_time_in_secs
         check_interval = runner_availability_check_interval_in_secs
@@ -199,10 +226,10 @@ module Terraform
         until elapsed_time >= max_wait_time
           sleep(check_interval)
           elapsed_time += check_interval
-          $embedded_terraform_log.debug("Waiting for terraform runner availability... (#{elapsed_time}/#{max_wait_time} seconds)")
+          $embedded_terraform_log.info("Waiting for terraform runner availability... (#{elapsed_time}/#{max_wait_time} seconds)")
 
           # Reset cache and check availability
-          @available = nil
+          @available = false
           break if available?
         end
 

--- a/lib/terraform/runner.rb
+++ b/lib/terraform/runner.rb
@@ -5,19 +5,37 @@ require 'base64'
 
 module Terraform
   class Runner
+    class TemporarilyUnavailable < StandardError; end
+
     class << self
       def available?
-        return @available if defined?(@available) && @available == true
-
         @available_mutex = Mutex.new unless defined?(@available_mutex)
+
+        # If previously available, return cached true
+        return true if defined?(@available) && @available == true
+
+        # If previously unavailable and within availability-cache TTL, return cached false
+        return false if availability_cache_live?
+
         @available_mutex.synchronize do
+          # Double-check inside mutex (another thread may have updated)
+          return false if availability_cache_live?
+
           # Fetch ready status from Terraform Runner service
           response = terraform_runner_client.get('ready')
           $embedded_terraform_log.debug("Terraform runner ready check response: #{response.body}")
           @available = response.status == 200 && JSON.parse(response.body)['status'] == 'UP'
+          @available_checked_at = Time.now.utc unless @available
+          @available
         rescue
           @available = false
+          @available_checked_at = Time.now.utc
+          false
         end
+      end
+
+      def reset_available!
+        reset_availability_cache!
       end
 
       # Run TerraformRunner Stack actions with a Terraform template.
@@ -115,7 +133,7 @@ module Terraform
         request = Request.new(ActionType::TEMPLATE_VARIABLES, {:template_path => template_path})
         action_endpoint = ActionType.action_endpoint(ActionType::TEMPLATE_VARIABLES)
 
-        http_response = post_with_retry(action_endpoint, request)
+        http_response = post(action_endpoint, request)
 
         $embedded_terraform_log.debug("==== http_response.body: \n #{http_response.body}")
         JSON.parse(http_response.body)
@@ -131,20 +149,8 @@ module Terraform
         @server_token ||= ENV.fetch('TERRAFORM_RUNNER_TOKEN', jwt_token)
       end
 
-      def stack_job_interval_in_secs
-        ENV.fetch('TERRAFORM_RUNNER_STACK_JOB_CHECK_INTERVAL', 10).to_i
-      end
-
-      def stack_job_max_time_in_secs
-        ENV.fetch('TERRAFORM_RUNNER_STACK_JOB_MAX_TIME', 120).to_i
-      end
-
-      def runner_availability_wait_time_in_secs
-        ENV.fetch('TERRAFORM_RUNNER_AVAILABILITY_WAIT_TIME', 600).to_i
-      end
-
-      def runner_availability_check_interval_in_secs
-        ENV.fetch('TERRAFORM_RUNNER_AVAILABILITY_CHECK_INTERVAL', 5).to_i
+      def availability_cache_ttl
+        ENV.fetch('TERRAFORM_RUNNER_AVAILABILITY_CACHE_TTL', 30).to_i # in seconds
       end
 
       # create http client for terraform-runner rest-api
@@ -169,7 +175,7 @@ module Terraform
       def run_terraform_runner_stack_api(request)
         action_endpoint = ActionType.action_endpoint(request.action_type)
 
-        http_response = post_with_retry(action_endpoint, request)
+        http_response = post(action_endpoint, request)
 
         if request.action_type == ActionType::CREATE
           $embedded_terraform_log.info("terraform-runnner #{action_endpoint} for #{request.options["name"]} is running ...")
@@ -184,71 +190,41 @@ module Terraform
         end
       end
 
-      # Post to terraform-runner API with retry logic for 503 errors and connection failures
+      # Post to terraform-runner API — single attempt, fail fast.
       #
       # @param action_endpoint [String] The API endpoint to post to
       # @param request [Terraform::Runner::Request] The request object containing the payload
       # @return [Faraday::Response] The HTTP response from the API
-      def post_with_retry(action_endpoint, request)
-        wait_for_runner_availability!
+      # @raise [Terraform::Runner::TemporarilyUnavailable] on 503 response or connection/timeout error
+      def post(action_endpoint, request)
+        http_response = terraform_runner_client.post(
+          action_endpoint,
+          *request.build_json_post_arguments
+        )
 
-        begin
-          http_response = terraform_runner_client.post(
-            action_endpoint,
-            *request.build_json_post_arguments
-          )
-
-          # If we get a 503 error, then wait for runner availability and retry once.
-          # Note: Only one retry is attempted for 503 errors. If the retry also returns 503,
-          # the method will return that failed response without further retry attempts.
-          if http_response.status == 503
-            $embedded_terraform_log.warn("Received 503 error from terraform runner, and migration is active, waiting for availability...")
-            # Reset availability cache before retry
-            @available_mutex.synchronize { @available = false }
-            wait_for_runner_availability!
-
-            http_response = terraform_runner_client.post(
-              action_endpoint,
-              *request.build_json_post_arguments
-            )
-          end
-        rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
-          $embedded_terraform_log.warn("Server not reachable: #{e.message}, waiting for availability...")
-          # Reset availability cache before retry
-          @available_mutex.synchronize { @available = false }
-          wait_for_runner_availability!
-
-          http_response = terraform_runner_client.post(
-            action_endpoint,
-            *request.build_json_post_arguments
-          )
+        if http_response.status == 503
+          reset_availability_cache!
+          raise Terraform::Runner::TemporarilyUnavailable, "Terraform runner returned 503"
         end
 
         http_response
+      rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
+        reset_availability_cache!
+        raise Terraform::Runner::TemporarilyUnavailable, "Terraform runner not reachable: #{e.message}"
       end
 
-      def wait_for_runner_availability!
-        return if available?
+      def availability_cache_live?
+        defined?(@available) &&
+          @available == false &&
+          @available_checked_at &&
+          ((Time.now.utc - @available_checked_at) < availability_cache_ttl)
+      end
 
-        $embedded_terraform_log.warn("Terraform runner is not available, waiting for up to #{runner_availability_wait_time_in_secs} seconds...")
-
-        max_wait_time = runner_availability_wait_time_in_secs
-        check_interval = runner_availability_check_interval_in_secs
-        elapsed_time = 0
-
-        until elapsed_time >= max_wait_time
-          sleep(check_interval)
-          elapsed_time += check_interval
-
-          $embedded_terraform_log.info("Waiting for terraform runner availability... (#{elapsed_time}/#{max_wait_time} seconds)")
-          break if available?
-        end
-
-        if available?
-          $embedded_terraform_log.info("Terraform runner is now available after #{elapsed_time} seconds")
-        else
-          $embedded_terraform_log.warn("Terraform runner did not become available within #{max_wait_time} seconds")
-          raise "Terraform runner is not available after waiting #{max_wait_time} seconds"
+      def reset_availability_cache!
+        @available_mutex = Mutex.new unless defined?(@available_mutex)
+        @available_mutex.synchronize do
+          @available = false
+          @available_checked_at = nil
         end
       end
 

--- a/lib/terraform/runner.rb
+++ b/lib/terraform/runner.rb
@@ -7,9 +7,10 @@ module Terraform
   class Runner
     class << self
       def available?
-        return @available if defined?(@available)
+        return true if @available
 
         response = terraform_runner_client.get('ready')
+        $embedded_terraform_log.debug("==== /ready : response.body: #{response.body}")
         @available = response.status == 200 && JSON.parse(response.body)['status'] == 'UP'
       rescue
         @available = false
@@ -136,6 +137,14 @@ module Terraform
         ENV.fetch('TERRAFORM_RUNNER_STACK_JOB_MAX_TIME', 120).to_i
       end
 
+      def runner_availability_wait_time_in_secs
+        ENV.fetch('TERRAFORM_RUNNER_AVAILABILITY_WAIT_TIME', 600).to_i
+      end
+
+      def runner_availability_check_interval_in_secs
+        ENV.fetch('TERRAFORM_RUNNER_AVAILABILITY_CHECK_INTERVAL', 5).to_i
+      end
+
       # create http client for terraform-runner rest-api
       def terraform_runner_client
         @terraform_runner_client ||= begin
@@ -156,6 +165,8 @@ module Terraform
       end
 
       def run_terraform_runner_stack_api(request)
+        wait_for_runner_availability
+
         action_endpoint = ActionType.action_endpoint(request.action_type)
 
         http_response = terraform_runner_client.post(
@@ -173,6 +184,29 @@ module Terraform
 
         Terraform::Runner::Response.parsed_response(http_response).tap do |resp|
           $embedded_terraform_log.info("terraform-runnner[#{action_endpoint}] stack/#{resp.stack_id}/#{resp.stack_job_id}")
+        end
+      end
+
+      def wait_for_runner_availability
+        return if available?
+
+        $embedded_terraform_log.info("Terraform runner is not available, waiting for up to #{runner_availability_wait_time_in_secs} seconds...")
+
+        max_wait_time = runner_availability_wait_time_in_secs
+        check_interval = runner_availability_check_interval_in_secs
+        elapsed_time = 0
+
+        until available? || elapsed_time >= max_wait_time
+          sleep(check_interval)
+          elapsed_time += check_interval
+          $embedded_terraform_log.debug("Waiting for terraform runner availability... (#{elapsed_time}/#{max_wait_time} seconds)")
+        end
+
+        if available?
+          $embedded_terraform_log.info("Terraform runner is now available after #{elapsed_time} seconds")
+        else
+          $embedded_terraform_log.warn("Terraform runner did not become available within #{max_wait_time} seconds")
+          raise "Terraform runner is not available after waiting #{max_wait_time} seconds"
         end
       end
 

--- a/lib/terraform/runner.rb
+++ b/lib/terraform/runner.rb
@@ -139,6 +139,10 @@ module Terraform
         JSON.parse(http_response.body)
       end
 
+      def availability_max_wait_time
+        ENV.fetch('TERRAFORM_RUNNER_AVAILABILITY_MAX_WAIT_TIME', 600).to_i
+      end
+
       private
 
       def server_url

--- a/lib/terraform/runner.rb
+++ b/lib/terraform/runner.rb
@@ -165,7 +165,7 @@ module Terraform
       end
 
       def run_terraform_runner_stack_api(request)
-        wait_for_runner_availability
+        wait_for_runner_availability!
 
         action_endpoint = ActionType.action_endpoint(request.action_type)
 
@@ -187,7 +187,7 @@ module Terraform
         end
       end
 
-      def wait_for_runner_availability
+      def wait_for_runner_availability!
         return if available?
 
         $embedded_terraform_log.info("Terraform runner is not available, waiting for up to #{runner_availability_wait_time_in_secs} seconds...")
@@ -196,10 +196,14 @@ module Terraform
         check_interval = runner_availability_check_interval_in_secs
         elapsed_time = 0
 
-        until available? || elapsed_time >= max_wait_time
+        until elapsed_time >= max_wait_time
           sleep(check_interval)
           elapsed_time += check_interval
           $embedded_terraform_log.debug("Waiting for terraform runner availability... (#{elapsed_time}/#{max_wait_time} seconds)")
+
+          # Reset cache and check availability
+          @available = nil
+          break if available?
         end
 
         if available?

--- a/lib/terraform/runner.rb
+++ b/lib/terraform/runner.rb
@@ -115,10 +115,7 @@ module Terraform
         request = Request.new(ActionType::TEMPLATE_VARIABLES, {:template_path => template_path})
         action_endpoint = ActionType.action_endpoint(ActionType::TEMPLATE_VARIABLES)
 
-        http_response = terraform_runner_client.post(
-          action_endpoint,
-          *request.build_json_post_arguments
-        )
+        http_response = post_with_retry(action_endpoint, request)
 
         $embedded_terraform_log.debug("==== http_response.body: \n #{http_response.body}")
         JSON.parse(http_response.body)
@@ -170,39 +167,9 @@ module Terraform
       end
 
       def run_terraform_runner_stack_api(request)
-        wait_for_runner_availability!
-
         action_endpoint = ActionType.action_endpoint(request.action_type)
 
-        begin
-          http_response = terraform_runner_client.post(
-            action_endpoint,
-            *request.build_json_post_arguments
-          )
-
-          # If we get a 503 error, then wait for runner availability and retry
-          if http_response.status == 503
-            $embedded_terraform_log.warn("Received 503 error from terraform runner, and migration is active, waiting for availability...")
-            # Reset cache and to check availability again
-            @available_mutex.synchronize { @available = false }
-            wait_for_runner_availability!
-
-            http_response = terraform_runner_client.post(
-              action_endpoint,
-              *request.build_json_post_arguments
-            )
-          end
-        rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
-          $embedded_terraform_log.warn("Server not reachable: #{e.message}, waiting for availability...")
-          # Reset cache and to check availability again
-          @available_mutex.synchronize { @available = false }
-          wait_for_runner_availability!
-
-          http_response = terraform_runner_client.post(
-            action_endpoint,
-            *request.build_json_post_arguments
-          )
-        end
+        http_response = post_with_retry(action_endpoint, request)
 
         if request.action_type == ActionType::CREATE
           $embedded_terraform_log.info("terraform-runnner #{action_endpoint} for #{request.options["name"]} is running ...")
@@ -215,6 +182,49 @@ module Terraform
         Terraform::Runner::Response.parsed_response(http_response).tap do |resp|
           $embedded_terraform_log.info("terraform-runnner[#{action_endpoint}] stack/#{resp.stack_id}/#{resp.stack_job_id}")
         end
+      end
+
+      # Post to terraform-runner API with retry logic for 503 errors and connection failures
+      #
+      # @param action_endpoint [String] The API endpoint to post to
+      # @param request [Terraform::Runner::Request] The request object containing the payload
+      # @return [Faraday::Response] The HTTP response from the API
+      def post_with_retry(action_endpoint, request)
+        wait_for_runner_availability!
+
+        begin
+          http_response = terraform_runner_client.post(
+            action_endpoint,
+            *request.build_json_post_arguments
+          )
+
+          # If we get a 503 error, then wait for runner availability and retry once.
+          # Note: Only one retry is attempted for 503 errors. If the retry also returns 503,
+          # the method will return that failed response without further retry attempts.
+          if http_response.status == 503
+            $embedded_terraform_log.warn("Received 503 error from terraform runner, and migration is active, waiting for availability...")
+            # Reset availability cache before retry
+            @available_mutex.synchronize { @available = false }
+            wait_for_runner_availability!
+
+            http_response = terraform_runner_client.post(
+              action_endpoint,
+              *request.build_json_post_arguments
+            )
+          end
+        rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
+          $embedded_terraform_log.warn("Server not reachable: #{e.message}, waiting for availability...")
+          # Reset availability cache before retry
+          @available_mutex.synchronize { @available = false }
+          wait_for_runner_availability!
+
+          http_response = terraform_runner_client.post(
+            action_endpoint,
+            *request.build_json_post_arguments
+          )
+        end
+
+        http_response
       end
 
       def wait_for_runner_availability!

--- a/lib/terraform/runner.rb
+++ b/lib/terraform/runner.rb
@@ -17,21 +17,27 @@ module Terraform
         # If previously unavailable and within availability-cache TTL, return cached false
         return false if availability_cache_live?
 
-        @available_mutex.synchronize do
-          # Double-check inside mutex (another thread may have updated)
-          return false if availability_cache_live?
+        if @available_mutex.try_lock
+          begin
+            # Double-check inside mutex (another thread may have updated)
+            return false if availability_cache_live?
 
-          # Fetch ready status from Terraform Runner service
-          response = terraform_runner_client.get('ready')
-          $embedded_terraform_log.debug("Terraform runner ready check response: #{response.body}")
-          @available = response.status == 200 && JSON.parse(response.body)['status'] == 'UP'
-          @available_checked_at = Time.now.utc unless @available
-          @available
-        rescue
+            # Fetch ready status from Terraform Runner service
+            response = terraform_runner_client.get('ready')
+            $embedded_terraform_log.debug("Terraform runner ready check response: #{response.body}")
+            @available = response.status == 200 && JSON.parse(response.body)['status'] == 'UP'
+            @available_checked_at = Time.now.utc unless @available
+          rescue
+            @available = false
+            @available_checked_at = Time.now.utc
+          ensure
+            @available_mutex.unlock # Ensure lock is always released
+          end
+        else
           @available = false
-          @available_checked_at = Time.now.utc
-          false
         end
+
+        @available
       end
 
       def reset_available!

--- a/lib/terraform/runner/api_params.rb
+++ b/lib/terraform/runner/api_params.rb
@@ -44,7 +44,6 @@ module Terraform
         end
       end
 
-      require 'set'
       TRUE_VALUES = ['T', 't', true, 'true', 'True', 'TRUE'].to_set
 
       # Normalize variables values, from ManageIQ values to Terraform Runner supported values

--- a/spec/lib/terraform/runner_spec.rb
+++ b/spec/lib/terraform/runner_spec.rb
@@ -33,93 +33,117 @@ RSpec.describe(Terraform::Runner) do
     end
   end
 
-  describe ".wait_for_runner_availability!" do
-    let(:wait_time) { 10 }
-    let(:check_interval) { 1 }
-
+  describe ".available? availability-cache TTL" do
     before do
-      stub_const("ENV", ENV.to_h.merge(
-                          "TERRAFORM_RUNNER_URL"                         => terraform_runner_url,
-                          "TERRAFORM_RUNNER_AVAILABILITY_WAIT_TIME"      => wait_time.to_s,
-                          "TERRAFORM_RUNNER_AVAILABILITY_CHECK_INTERVAL" => check_interval.to_s
-                        ))
-      # Reset the @available instance variable before each test
       Terraform::Runner.instance_variable_set(:@available, nil)
+      Terraform::Runner.instance_variable_set(:@available_checked_at, nil)
     end
 
-    context "when runner is immediately available" do
-      before do
-        stub_request(:get, "#{terraform_runner_url}/ready")
-          .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
-      end
-
-      it "does not wait and proceeds immediately" do
-        expect(Terraform::Runner).not_to receive(:sleep)
-        Terraform::Runner.send(:wait_for_runner_availability!)
-      end
-    end
-
-    context "when runner becomes available after waiting" do
-      before do
-        # First 2 calls return unavailable, 3rd call returns available
-        stub_request(:get, "#{terraform_runner_url}/ready")
-          .to_return(:status => 503, :body => {:status => "DOWN"}.to_json)
-          .times(2)
-          .then
-          .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
-      end
-
-      it "waits and succeeds when runner becomes available" do
-        expect(Terraform::Runner).to receive(:sleep).with(check_interval).twice
-        expect { Terraform::Runner.send(:wait_for_runner_availability!) }.not_to raise_error
-      end
-    end
-
-    context "when runner never becomes available" do
+    context "when /ready returns 503 (unavailable)" do
       before do
         stub_request(:get, "#{terraform_runner_url}/ready")
           .to_return(:status => 503, :body => {:status => "DOWN"}.to_json)
       end
 
-      it "raises an error after timeout" do
-        expect(Terraform::Runner).to receive(:sleep).with(check_interval).at_least(:once)
-        expect { Terraform::Runner.send(:wait_for_runner_availability!) }
-          .to raise_error(RuntimeError, /Terraform runner is not available after waiting/)
+      it "returns false and caches the result within the TTL window" do
+        stub_const("ENV", ENV.to_h.merge(
+                            "TERRAFORM_RUNNER_URL"                    => terraform_runner_url,
+                            "TERRAFORM_RUNNER_AVAILABILITY_CACHE_TTL" => "30"
+                          ))
+
+        expect(Terraform::Runner.available?).to eq(false)
+
+        # A second call should NOT re-hit /ready (within TTL) — allow_any_instance_of
+        # ensures no new request is made by asserting only 1 request total
+        expect(WebMock).to have_requested(:get, "#{terraform_runner_url}/ready").times(1)
+
+        expect(Terraform::Runner.available?).to eq(false)
+        expect(WebMock).to have_requested(:get, "#{terraform_runner_url}/ready").times(1)
+      end
+
+      it "re-checks /ready after the TTL expires" do
+        stub_const("ENV", ENV.to_h.merge(
+                            "TERRAFORM_RUNNER_URL"                    => terraform_runner_url,
+                            "TERRAFORM_RUNNER_AVAILABILITY_CACHE_TTL" => "30"
+                          ))
+
+        expect(Terraform::Runner.available?).to eq(false)
+
+        # Simulate TTL expiry by backdating @available_checked_at
+        Terraform::Runner.instance_variable_set(:@available_checked_at, Time.now.utc - 31)
+
+        expect(Terraform::Runner.available?).to eq(false)
+        # Two requests: first check + re-check after TTL expiry
+        expect(WebMock).to have_requested(:get, "#{terraform_runner_url}/ready").times(2)
       end
     end
 
-    context "when runner has connection errors" do
+    context "when /ready returns 200 (available)" do
       before do
-        # First 2 calls raise errors, 3rd call succeeds
         stub_request(:get, "#{terraform_runner_url}/ready")
-          .to_raise(Faraday::ConnectionFailed)
-          .times(2)
-          .then
           .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
       end
 
-      it "retries and succeeds when connection is restored" do
-        expect(Terraform::Runner).to receive(:sleep).with(check_interval).twice
-        expect { Terraform::Runner.send(:wait_for_runner_availability!) }.not_to raise_error
+      it "returns true and caches indefinitely (no TTL on positive result)" do
+        expect(Terraform::Runner.available?).to eq(true)
+        expect(Terraform::Runner.available?).to eq(true)
+        # Still only one HTTP request — positive result cached permanently
+        expect(WebMock).to have_requested(:get, "#{terraform_runner_url}/ready").times(1)
       end
     end
   end
 
-  describe ".run_terraform_runner_stack_api with availability check" do
-    let(:wait_time) { 10 }
-    let(:check_interval) { 1 }
-
+  describe ".reset_available!" do
     before do
-      stub_const("ENV", ENV.to_h.merge(
-                          "TERRAFORM_RUNNER_URL"                         => terraform_runner_url,
-                          "TERRAFORM_RUNNER_AVAILABILITY_WAIT_TIME"      => wait_time.to_s,
-                          "TERRAFORM_RUNNER_AVAILABILITY_CHECK_INTERVAL" => check_interval.to_s
-                        ))
-      # Reset the @available instance variable before each test
       Terraform::Runner.instance_variable_set(:@available, nil)
+      Terraform::Runner.instance_variable_set(:@available_checked_at, nil)
     end
 
-    context "when runner is available" do
+    it "clears the positive availability cache so the next available? re-checks /ready" do
+      stub_request(:get, "#{terraform_runner_url}/ready")
+        .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
+
+      expect(Terraform::Runner.available?).to eq(true)
+      expect(Terraform::Runner.instance_variable_get(:@available)).to eq(true)
+
+      Terraform::Runner.reset_available!
+
+      expect(Terraform::Runner.instance_variable_get(:@available)).to eq(false)
+      expect(Terraform::Runner.instance_variable_get(:@available_checked_at)).to be_nil
+    end
+
+    it "clears @available_checked_at so the availability-cache TTL is bypassed on next available? call" do
+      stub_request(:get, "#{terraform_runner_url}/ready")
+        .to_return(:status => 503, :body => {:status => "DOWN"}.to_json)
+        .times(1)
+        .then
+        .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
+
+      stub_const("ENV", ENV.to_h.merge(
+                          "TERRAFORM_RUNNER_URL"                    => terraform_runner_url,
+                          "TERRAFORM_RUNNER_AVAILABILITY_CACHE_TTL" => "30"
+                        ))
+
+      # First call: unavailable, availability-cache set
+      expect(Terraform::Runner.available?).to eq(false)
+      expect(Terraform::Runner.instance_variable_get(:@available_checked_at)).not_to be_nil
+
+      # reset! clears the timestamp so next call bypasses TTL
+      Terraform::Runner.reset_available!
+      expect(Terraform::Runner.instance_variable_get(:@available_checked_at)).to be_nil
+
+      # Second call now re-checks /ready and finds it up
+      expect(Terraform::Runner.available?).to eq(true)
+    end
+  end
+
+  describe ".run_terraform_runner_stack_api raises TemporarilyUnavailable" do
+    before do
+      Terraform::Runner.instance_variable_set(:@available, nil)
+      Terraform::Runner.instance_variable_set(:@available_checked_at, nil)
+    end
+
+    context "when runner is available and API call succeeds" do
       before do
         stub_request(:get, "#{terraform_runner_url}/ready")
           .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
@@ -130,9 +154,7 @@ RSpec.describe(Terraform::Runner) do
           .to_return(:status => 200, :body => @hello_world_create_response.to_json)
       end
 
-      it "proceeds with the API call without waiting" do
-        expect(Terraform::Runner).not_to receive(:sleep)
-
+      it "proceeds with the API call normally" do
         Terraform::Runner.run(
           Terraform::Runner::ActionType::CREATE,
           File.join(__dir__, "runner/data/hello-world"),
@@ -143,88 +165,8 @@ RSpec.describe(Terraform::Runner) do
       end
     end
 
-    context "when runner becomes available after waiting" do
+    context "when API returns 503" do
       before do
-        # Reset @available to ensure fresh state
-        Terraform::Runner.instance_variable_set(:@available, nil)
-
-        # First call returns unavailable, second call returns available
-        stub_request(:get, "#{terraform_runner_url}/ready")
-          .to_return(:status => 503, :body => {:status => "DOWN"}.to_json)
-          .times(1)
-          .then
-          .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
-      end
-
-      let!(:create_stub) do
-        stub_request(:post, "#{terraform_runner_url}/api/stack/create")
-          .to_return(:status => 200, :body => @hello_world_create_response.to_json)
-      end
-
-      it "waits for availability then proceeds with the API call" do
-        expect(Terraform::Runner).to receive(:sleep).with(check_interval).once
-
-        Terraform::Runner.run(
-          Terraform::Runner::ActionType::CREATE,
-          File.join(__dir__, "runner/data/hello-world"),
-          {}
-        )
-
-        expect(create_stub).to have_been_requested.times(1)
-      end
-    end
-
-    context "when runner never becomes available" do
-      before do
-        stub_request(:get, "#{terraform_runner_url}/ready")
-          .to_return(:status => 503, :body => {:status => "DOWN"}.to_json)
-      end
-
-      it "raises an error and does not make the API call" do
-        create_stub = stub_request(:post, "#{terraform_runner_url}/api/stack/create")
-
-        expect do
-          Terraform::Runner.run(
-            Terraform::Runner::ActionType::CREATE,
-            File.join(__dir__, "runner/data/hello-world"),
-            {}
-          )
-        end.to raise_error(RuntimeError, /Terraform runner is not available after waiting/)
-
-        expect(create_stub).not_to have_been_requested
-      end
-    end
-  end
-
-  describe ".run_terraform_runner_stack_api with 503 error handling" do
-    let(:wait_time) { 10 }
-    let(:check_interval) { 1 }
-
-    before do
-      stub_const("ENV", ENV.to_h.merge(
-                          "TERRAFORM_RUNNER_URL"                         => terraform_runner_url,
-                          "TERRAFORM_RUNNER_AVAILABILITY_WAIT_TIME"      => wait_time.to_s,
-                          "TERRAFORM_RUNNER_AVAILABILITY_CHECK_INTERVAL" => check_interval.to_s
-                        ))
-      # Reset the @available instance variable before each test
-      Terraform::Runner.instance_variable_set(:@available, nil)
-    end
-
-    context "when API returns 503 error then succeeds on retry" do
-      before do
-        # Runner is initially available
-        stub_request(:get, "#{terraform_runner_url}/ready")
-          .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
-          .times(1)
-          .then
-          # After 503, runner becomes unavailable then available again
-          .to_return(:status => 503, :body => {:status => "DOWN"}.to_json)
-          .times(1)
-          .then
-          .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
-      end
-
-      let!(:create_stub) do
         stub_request(:post, "#{terraform_runner_url}/api/stack/create")
           .to_return(:status => 503, :body => {
             :error => {
@@ -233,106 +175,73 @@ RSpec.describe(Terraform::Runner) do
               :message    => "API is temporarily unavailable due to an active database migration."
             }
           }.to_json)
-          .times(1)
-          .then
-          .to_return(:status => 200, :body => @hello_world_create_response.to_json)
       end
 
-      it "waits for availability and retries the request" do
-        expect(Terraform::Runner).to receive(:sleep).with(check_interval).once
+      it "raises TemporarilyUnavailable and does not sleep" do
+        expect(Terraform::Runner).not_to receive(:sleep)
 
-        Terraform::Runner.run(
-          Terraform::Runner::ActionType::CREATE,
-          File.join(__dir__, "runner/data/hello-world"),
-          {}
-        )
-
-        expect(create_stub).to have_been_requested.times(2)
+        expect do
+          Terraform::Runner.run(
+            Terraform::Runner::ActionType::CREATE,
+            File.join(__dir__, "runner/data/hello-world"),
+            {}
+          )
+        end.to raise_error(Terraform::Runner::TemporarilyUnavailable)
       end
-    end
-  end
 
-  describe ".run_terraform_runner_stack_api with connection error handling" do
-    let(:wait_time) { 10 }
-    let(:check_interval) { 1 }
-
-    before do
-      stub_const("ENV", ENV.to_h.merge(
-                          "TERRAFORM_RUNNER_URL"                         => terraform_runner_url,
-                          "TERRAFORM_RUNNER_AVAILABILITY_WAIT_TIME"      => wait_time.to_s,
-                          "TERRAFORM_RUNNER_AVAILABILITY_CHECK_INTERVAL" => check_interval.to_s
-                        ))
-      # Reset the @available instance variable before each test
-      Terraform::Runner.instance_variable_set(:@available, nil)
-    end
-
-    context "when API raises ConnectionFailed then succeeds on retry" do
-      before do
-        # Runner is initially available
+      it "resets the availability cache so the next available? check re-queries /ready" do
         stub_request(:get, "#{terraform_runner_url}/ready")
           .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
-          .times(1)
-          .then
-          # After connection failure, runner becomes unavailable then available again
-          .to_return(:status => 503, :body => {:status => "DOWN"}.to_json)
-          .times(1)
-          .then
-          .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
-      end
 
-      let!(:create_stub) do
+        expect do
+          Terraform::Runner.run(
+            Terraform::Runner::ActionType::CREATE,
+            File.join(__dir__, "runner/data/hello-world"),
+            {}
+          )
+        end.to raise_error(Terraform::Runner::TemporarilyUnavailable)
+
+        # After reset, @available_checked_at is nil so next available? re-checks
+        expect(Terraform::Runner.instance_variable_get(:@available)).to eq(false)
+        expect(Terraform::Runner.instance_variable_get(:@available_checked_at)).to be_nil
+      end
+    end
+
+    context "when API raises Faraday::ConnectionFailed" do
+      before do
         stub_request(:post, "#{terraform_runner_url}/api/stack/create")
           .to_raise(Faraday::ConnectionFailed.new("Connection refused"))
-          .times(1)
-          .then
-          .to_return(:status => 200, :body => @hello_world_create_response.to_json)
       end
 
-      it "waits for availability and retries the request" do
-        expect(Terraform::Runner).to receive(:sleep).with(check_interval).once
+      it "raises TemporarilyUnavailable without sleeping" do
+        expect(Terraform::Runner).not_to receive(:sleep)
 
-        Terraform::Runner.run(
-          Terraform::Runner::ActionType::CREATE,
-          File.join(__dir__, "runner/data/hello-world"),
-          {}
-        )
-
-        expect(create_stub).to have_been_requested.times(2)
+        expect do
+          Terraform::Runner.run(
+            Terraform::Runner::ActionType::CREATE,
+            File.join(__dir__, "runner/data/hello-world"),
+            {}
+          )
+        end.to raise_error(Terraform::Runner::TemporarilyUnavailable, /Connection refused/)
       end
     end
 
-    context "when API raises TimeoutError then succeeds on retry" do
+    context "when API raises Faraday::TimeoutError" do
       before do
-        # Runner is initially available
-        stub_request(:get, "#{terraform_runner_url}/ready")
-          .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
-          .times(1)
-          .then
-          # After timeout, runner becomes unavailable then available again
-          .to_return(:status => 503, :body => {:status => "DOWN"}.to_json)
-          .times(1)
-          .then
-          .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
-      end
-
-      let!(:create_stub) do
         stub_request(:post, "#{terraform_runner_url}/api/stack/create")
           .to_raise(Faraday::TimeoutError.new("Request timeout"))
-          .times(1)
-          .then
-          .to_return(:status => 200, :body => @hello_world_create_response.to_json)
       end
 
-      it "waits for availability and retries the request" do
-        expect(Terraform::Runner).to receive(:sleep).with(check_interval).once
+      it "raises TemporarilyUnavailable without sleeping" do
+        expect(Terraform::Runner).not_to receive(:sleep)
 
-        Terraform::Runner.run(
-          Terraform::Runner::ActionType::CREATE,
-          File.join(__dir__, "runner/data/hello-world"),
-          {}
-        )
-
-        expect(create_stub).to have_been_requested.times(2)
+        expect do
+          Terraform::Runner.run(
+            Terraform::Runner::ActionType::CREATE,
+            File.join(__dir__, "runner/data/hello-world"),
+            {}
+          )
+        end.to raise_error(Terraform::Runner::TemporarilyUnavailable, /Request timeout/)
       end
     end
   end
@@ -932,116 +841,30 @@ RSpec.describe(Terraform::Runner) do
       end
     end
 
-    describe '.parse_template_variables with availability check' do
-      let(:wait_time) { 10 }
-      let(:check_interval) { 1 }
+    describe '.parse_template_variables raises TemporarilyUnavailable' do
       let(:hello_world_variables_response) { JSON.parse(File.read(File.join(__dir__, "runner/data/responses/hello-world-variables-success.json"))) }
 
       before do
-        stub_const("ENV", ENV.to_h.merge(
-                            "TERRAFORM_RUNNER_URL"                         => terraform_runner_url,
-                            "TERRAFORM_RUNNER_AVAILABILITY_WAIT_TIME"      => wait_time.to_s,
-                            "TERRAFORM_RUNNER_AVAILABILITY_CHECK_INTERVAL" => check_interval.to_s
-                          ))
-        # Reset the @available instance variable before each test
         Terraform::Runner.instance_variable_set(:@available, nil)
+        Terraform::Runner.instance_variable_set(:@available_checked_at, nil)
       end
 
-      context "when runner is available" do
+      context "when API call succeeds" do
         before do
-          stub_request(:get, "#{terraform_runner_url}/ready")
-            .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
-        end
-
-        let!(:template_variables_stub) do
           stub_request(:post, "#{terraform_runner_url}/api/template/variables")
             .to_return(:status => 200, :body => hello_world_variables_response.to_json)
         end
 
-        it "proceeds with the API call without waiting" do
+        it "returns the parsed response without sleeping" do
           expect(Terraform::Runner).not_to receive(:sleep)
 
-          Terraform::Runner.parse_template_variables(File.join(__dir__, "runner/data/hello-world"))
-
-          expect(template_variables_stub).to have_been_requested.times(1)
+          response = Terraform::Runner.parse_template_variables(File.join(__dir__, "runner/data/hello-world"))
+          expect(response).to have_key('template_input_params')
         end
       end
 
-      context "when runner becomes available after waiting" do
+      context "when API returns 503" do
         before do
-          # Reset @available to ensure fresh state
-          Terraform::Runner.instance_variable_set(:@available, nil)
-
-          # First call returns unavailable, second call returns available
-          stub_request(:get, "#{terraform_runner_url}/ready")
-            .to_return(:status => 503, :body => {:status => "DOWN"}.to_json)
-            .times(1)
-            .then
-            .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
-        end
-
-        let!(:template_variables_stub) do
-          stub_request(:post, "#{terraform_runner_url}/api/template/variables")
-            .to_return(:status => 200, :body => hello_world_variables_response.to_json)
-        end
-
-        it "waits for availability then proceeds with the API call" do
-          expect(Terraform::Runner).to receive(:sleep).with(check_interval).once
-
-          Terraform::Runner.parse_template_variables(File.join(__dir__, "runner/data/hello-world"))
-
-          expect(template_variables_stub).to have_been_requested.times(1)
-        end
-      end
-
-      context "when runner never becomes available" do
-        before do
-          stub_request(:get, "#{terraform_runner_url}/ready")
-            .to_return(:status => 503, :body => {:status => "DOWN"}.to_json)
-        end
-
-        it "raises an error and does not make the API call" do
-          template_variables_stub = stub_request(:post, "#{terraform_runner_url}/api/template/variables")
-
-          expect do
-            Terraform::Runner.parse_template_variables(File.join(__dir__, "runner/data/hello-world"))
-          end.to raise_error(RuntimeError, /Terraform runner is not available after waiting/)
-
-          expect(template_variables_stub).not_to have_been_requested
-        end
-      end
-    end
-
-    describe '.parse_template_variables with 503 error handling' do
-      let(:wait_time) { 10 }
-      let(:check_interval) { 1 }
-      let(:hello_world_variables_response) { JSON.parse(File.read(File.join(__dir__, "runner/data/responses/hello-world-variables-success.json"))) }
-
-      before do
-        stub_const("ENV", ENV.to_h.merge(
-                            "TERRAFORM_RUNNER_URL"                         => terraform_runner_url,
-                            "TERRAFORM_RUNNER_AVAILABILITY_WAIT_TIME"      => wait_time.to_s,
-                            "TERRAFORM_RUNNER_AVAILABILITY_CHECK_INTERVAL" => check_interval.to_s
-                          ))
-        # Reset the @available instance variable before each test
-        Terraform::Runner.instance_variable_set(:@available, nil)
-      end
-
-      context "when API returns 503 error then succeeds on retry" do
-        before do
-          # Runner is initially available
-          stub_request(:get, "#{terraform_runner_url}/ready")
-            .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
-            .times(1)
-            .then
-            # After 503, runner becomes unavailable then available again
-            .to_return(:status => 503, :body => {:status => "DOWN"}.to_json)
-            .times(1)
-            .then
-            .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
-        end
-
-        let!(:template_variables_stub) do
           stub_request(:post, "#{terraform_runner_url}/api/template/variables")
             .to_return(:status => 503, :body => {
               :error => {
@@ -1050,95 +873,44 @@ RSpec.describe(Terraform::Runner) do
                 :message    => "API is temporarily unavailable due to an active database migration."
               }
             }.to_json)
-            .times(1)
-            .then
-            .to_return(:status => 200, :body => hello_world_variables_response.to_json)
         end
 
-        it "waits for availability and retries the request" do
-          expect(Terraform::Runner).to receive(:sleep).with(check_interval).once
+        it "raises TemporarilyUnavailable without sleeping" do
+          expect(Terraform::Runner).not_to receive(:sleep)
 
-          Terraform::Runner.parse_template_variables(File.join(__dir__, "runner/data/hello-world"))
-
-          expect(template_variables_stub).to have_been_requested.times(2)
+          expect do
+            Terraform::Runner.parse_template_variables(File.join(__dir__, "runner/data/hello-world"))
+          end.to raise_error(Terraform::Runner::TemporarilyUnavailable)
         end
       end
-    end
 
-    describe '.parse_template_variables with connection error handling' do
-      let(:wait_time) { 10 }
-      let(:check_interval) { 1 }
-      let(:hello_world_variables_response) { JSON.parse(File.read(File.join(__dir__, "runner/data/responses/hello-world-variables-success.json"))) }
-
-      before do
-        stub_const("ENV", ENV.to_h.merge(
-                            "TERRAFORM_RUNNER_URL"                         => terraform_runner_url,
-                            "TERRAFORM_RUNNER_AVAILABILITY_WAIT_TIME"      => wait_time.to_s,
-                            "TERRAFORM_RUNNER_AVAILABILITY_CHECK_INTERVAL" => check_interval.to_s
-                          ))
-        # Reset the @available instance variable before each test
-        Terraform::Runner.instance_variable_set(:@available, nil)
-      end
-
-      context "when API raises ConnectionFailed then succeeds on retry" do
+      context "when API raises Faraday::ConnectionFailed" do
         before do
-          # Runner is initially available
-          stub_request(:get, "#{terraform_runner_url}/ready")
-            .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
-            .times(1)
-            .then
-            # After connection failure, runner becomes unavailable then available again
-            .to_return(:status => 503, :body => {:status => "DOWN"}.to_json)
-            .times(1)
-            .then
-            .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
-        end
-
-        let!(:template_variables_stub) do
           stub_request(:post, "#{terraform_runner_url}/api/template/variables")
             .to_raise(Faraday::ConnectionFailed.new("Connection refused"))
-            .times(1)
-            .then
-            .to_return(:status => 200, :body => hello_world_variables_response.to_json)
         end
 
-        it "waits for availability and retries the request" do
-          expect(Terraform::Runner).to receive(:sleep).with(check_interval).once
+        it "raises TemporarilyUnavailable without sleeping" do
+          expect(Terraform::Runner).not_to receive(:sleep)
 
-          Terraform::Runner.parse_template_variables(File.join(__dir__, "runner/data/hello-world"))
-
-          expect(template_variables_stub).to have_been_requested.times(2)
+          expect do
+            Terraform::Runner.parse_template_variables(File.join(__dir__, "runner/data/hello-world"))
+          end.to raise_error(Terraform::Runner::TemporarilyUnavailable, /Connection refused/)
         end
       end
 
-      context "when API raises TimeoutError then succeeds on retry" do
+      context "when API raises Faraday::TimeoutError" do
         before do
-          # Runner is initially available
-          stub_request(:get, "#{terraform_runner_url}/ready")
-            .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
-            .times(1)
-            .then
-            # After timeout, runner becomes unavailable then available again
-            .to_return(:status => 503, :body => {:status => "DOWN"}.to_json)
-            .times(1)
-            .then
-            .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
-        end
-
-        let!(:template_variables_stub) do
           stub_request(:post, "#{terraform_runner_url}/api/template/variables")
             .to_raise(Faraday::TimeoutError.new("Request timeout"))
-            .times(1)
-            .then
-            .to_return(:status => 200, :body => hello_world_variables_response.to_json)
         end
 
-        it "waits for availability and retries the request" do
-          expect(Terraform::Runner).to receive(:sleep).with(check_interval).once
+        it "raises TemporarilyUnavailable without sleeping" do
+          expect(Terraform::Runner).not_to receive(:sleep)
 
-          Terraform::Runner.parse_template_variables(File.join(__dir__, "runner/data/hello-world"))
-
-          expect(template_variables_stub).to have_been_requested.times(2)
+          expect do
+            Terraform::Runner.parse_template_variables(File.join(__dir__, "runner/data/hello-world"))
+          end.to raise_error(Terraform::Runner::TemporarilyUnavailable, /Request timeout/)
         end
       end
     end

--- a/spec/lib/terraform/runner_spec.rb
+++ b/spec/lib/terraform/runner_spec.rb
@@ -33,8 +33,176 @@ RSpec.describe(Terraform::Runner) do
     end
   end
 
+  describe ".wait_for_runner_availability!" do
+    let(:wait_time) { 10 }
+    let(:check_interval) { 1 }
+
+    before do
+      stub_const("ENV", ENV.to_h.merge(
+                          "TERRAFORM_RUNNER_URL"                         => terraform_runner_url,
+                          "TERRAFORM_RUNNER_AVAILABILITY_WAIT_TIME"      => wait_time.to_s,
+                          "TERRAFORM_RUNNER_AVAILABILITY_CHECK_INTERVAL" => check_interval.to_s
+                        ))
+      # Reset the @available instance variable before each test
+      Terraform::Runner.instance_variable_set(:@available, nil)
+    end
+
+    context "when runner is immediately available" do
+      before do
+        stub_request(:get, "#{terraform_runner_url}/ready")
+          .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
+      end
+
+      it "does not wait and proceeds immediately" do
+        expect(Terraform::Runner).not_to receive(:sleep)
+        Terraform::Runner.send(:wait_for_runner_availability!)
+      end
+    end
+
+    context "when runner becomes available after waiting" do
+      before do
+        # First 2 calls return unavailable, 3rd call returns available
+        stub_request(:get, "#{terraform_runner_url}/ready")
+          .to_return(:status => 503, :body => {:status => "DOWN"}.to_json)
+          .times(2)
+          .then
+          .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
+      end
+
+      it "waits and succeeds when runner becomes available" do
+        expect(Terraform::Runner).to receive(:sleep).with(check_interval).twice
+        expect { Terraform::Runner.send(:wait_for_runner_availability!) }.not_to raise_error
+      end
+    end
+
+    context "when runner never becomes available" do
+      before do
+        stub_request(:get, "#{terraform_runner_url}/ready")
+          .to_return(:status => 503, :body => {:status => "DOWN"}.to_json)
+      end
+
+      it "raises an error after timeout" do
+        expect(Terraform::Runner).to receive(:sleep).with(check_interval).at_least(:once)
+        expect { Terraform::Runner.send(:wait_for_runner_availability!) }
+          .to raise_error(RuntimeError, /Terraform runner is not available after waiting/)
+      end
+    end
+
+    context "when runner has connection errors" do
+      before do
+        # First 2 calls raise errors, 3rd call succeeds
+        stub_request(:get, "#{terraform_runner_url}/ready")
+          .to_raise(Faraday::ConnectionFailed)
+          .times(2)
+          .then
+          .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
+      end
+
+      it "retries and succeeds when connection is restored" do
+        expect(Terraform::Runner).to receive(:sleep).with(check_interval).twice
+        expect { Terraform::Runner.send(:wait_for_runner_availability!) }.not_to raise_error
+      end
+    end
+  end
+
+  describe ".run_terraform_runner_stack_api with availability check" do
+    let(:wait_time) { 10 }
+    let(:check_interval) { 1 }
+
+    before do
+      stub_const("ENV", ENV.to_h.merge(
+                          "TERRAFORM_RUNNER_URL"                         => terraform_runner_url,
+                          "TERRAFORM_RUNNER_AVAILABILITY_WAIT_TIME"      => wait_time.to_s,
+                          "TERRAFORM_RUNNER_AVAILABILITY_CHECK_INTERVAL" => check_interval.to_s
+                        ))
+      # Reset the @available instance variable before each test
+      Terraform::Runner.instance_variable_set(:@available, nil)
+    end
+
+    context "when runner is available" do
+      before do
+        stub_request(:get, "#{terraform_runner_url}/ready")
+          .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
+      end
+
+      let!(:create_stub) do
+        stub_request(:post, "#{terraform_runner_url}/api/stack/create")
+          .to_return(:status => 200, :body => @hello_world_create_response.to_json)
+      end
+
+      it "proceeds with the API call without waiting" do
+        expect(Terraform::Runner).not_to receive(:sleep)
+
+        Terraform::Runner.run(
+          Terraform::Runner::ActionType::CREATE,
+          File.join(__dir__, "runner/data/hello-world"),
+          {}
+        )
+
+        expect(create_stub).to have_been_requested.times(1)
+      end
+    end
+
+    context "when runner becomes available after waiting" do
+      before do
+        # Reset @available to ensure fresh state
+        Terraform::Runner.instance_variable_set(:@available, nil)
+
+        # First call returns unavailable, second call returns available
+        stub_request(:get, "#{terraform_runner_url}/ready")
+          .to_return(:status => 503, :body => {:status => "DOWN"}.to_json)
+          .times(1)
+          .then
+          .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
+      end
+
+      let!(:create_stub) do
+        stub_request(:post, "#{terraform_runner_url}/api/stack/create")
+          .to_return(:status => 200, :body => @hello_world_create_response.to_json)
+      end
+
+      it "waits for availability then proceeds with the API call" do
+        expect(Terraform::Runner).to receive(:sleep).with(check_interval).once
+
+        Terraform::Runner.run(
+          Terraform::Runner::ActionType::CREATE,
+          File.join(__dir__, "runner/data/hello-world"),
+          {}
+        )
+
+        expect(create_stub).to have_been_requested.times(1)
+      end
+    end
+
+    context "when runner never becomes available" do
+      before do
+        stub_request(:get, "#{terraform_runner_url}/ready")
+          .to_return(:status => 503, :body => {:status => "DOWN"}.to_json)
+      end
+
+      it "raises an error and does not make the API call" do
+        create_stub = stub_request(:post, "#{terraform_runner_url}/api/stack/create")
+
+        expect do
+          Terraform::Runner.run(
+            Terraform::Runner::ActionType::CREATE,
+            File.join(__dir__, "runner/data/hello-world"),
+            {}
+          )
+        end.to raise_error(RuntimeError, /Terraform runner is not available after waiting/)
+
+        expect(create_stub).not_to have_been_requested
+      end
+    end
+  end
+
   context 'Create Stack for hello-world terraform template' do
     describe '.run create stack with input_vars' do
+      before do
+        stub_request(:get, "#{terraform_runner_url}/ready")
+          .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
+      end
+
       def verify_req(req)
         body = JSON.parse(req.body)
         expect(body["name"]).to(start_with('stack-'))
@@ -117,6 +285,11 @@ RSpec.describe(Terraform::Runner) do
     end
 
     describe 'ResponseAsync' do
+      before do
+        stub_request(:get, "#{terraform_runner_url}/ready")
+          .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
+      end
+
       let!(:retrieve_stub) do
         stub_request(:post, "#{terraform_runner_url}/api/stack/retrieve")
           .with(
@@ -187,6 +360,11 @@ RSpec.describe(Terraform::Runner) do
     end
 
     describe 'Stop running a create-stack job' do
+      before do
+        stub_request(:get, "#{terraform_runner_url}/ready")
+          .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
+      end
+
       let!(:create_stub) do
         stub_request(:post, "#{terraform_runner_url}/api/stack/create")
           .with(:body => hash_including({:parameters => [], :cloud_providers => []}))
@@ -268,6 +446,11 @@ RSpec.describe(Terraform::Runner) do
     end
 
     describe 'Update stack for Reconfiguration of created stack' do
+      before do
+        stub_request(:get, "#{terraform_runner_url}/ready")
+          .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
+      end
+
       def verify_req(req)
         body = JSON.parse(req.body)
         expect(body["stack_id"]).to eq(@hello_world_retrieve_update_response['stack_id'])
@@ -327,6 +510,11 @@ RSpec.describe(Terraform::Runner) do
     end
 
     describe 'Delete stack for Retirement of created stack' do
+      before do
+        stub_request(:get, "#{terraform_runner_url}/ready")
+          .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
+      end
+
       def verify_req(req)
         body = JSON.parse(req.body)
         expect(body["stack_id"]).to(eq(@hello_world_retrieve_delete_response['stack_id']))
@@ -389,6 +577,11 @@ RSpec.describe(Terraform::Runner) do
 
   context 'Create stack with cloud credentials' do
     describe 'Create stack with amazon credential' do
+      before do
+        stub_request(:get, "#{terraform_runner_url}/ready")
+          .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
+      end
+
       let(:amazon_cred) do
         params = {
           :userid         => "manageiq-aws",
@@ -456,6 +649,11 @@ RSpec.describe(Terraform::Runner) do
     end
 
     describe 'Create stack with vSphere & ibmcloud credential' do
+      before do
+        stub_request(:get, "#{terraform_runner_url}/ready")
+          .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
+      end
+
       let(:vsphere_cred) do
         params = {
           :userid   => "userid",

--- a/spec/lib/terraform/runner_spec.rb
+++ b/spec/lib/terraform/runner_spec.rb
@@ -196,6 +196,147 @@ RSpec.describe(Terraform::Runner) do
     end
   end
 
+  describe ".run_terraform_runner_stack_api with 503 error handling" do
+    let(:wait_time) { 10 }
+    let(:check_interval) { 1 }
+
+    before do
+      stub_const("ENV", ENV.to_h.merge(
+                          "TERRAFORM_RUNNER_URL"                         => terraform_runner_url,
+                          "TERRAFORM_RUNNER_AVAILABILITY_WAIT_TIME"      => wait_time.to_s,
+                          "TERRAFORM_RUNNER_AVAILABILITY_CHECK_INTERVAL" => check_interval.to_s
+                        ))
+      # Reset the @available instance variable before each test
+      Terraform::Runner.instance_variable_set(:@available, nil)
+    end
+
+    context "when API returns 503 error then succeeds on retry" do
+      before do
+        # Runner is initially available
+        stub_request(:get, "#{terraform_runner_url}/ready")
+          .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
+          .times(1)
+          .then
+          # After 503, runner becomes unavailable then available again
+          .to_return(:status => 503, :body => {:status => "DOWN"}.to_json)
+          .times(1)
+          .then
+          .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
+      end
+
+      let!(:create_stub) do
+        stub_request(:post, "#{terraform_runner_url}/api/stack/create")
+          .to_return(:status => 503, :body => {
+            :error => {
+              :statusCode => 503,
+              :name       => "ServiceUnavailable",
+              :message    => "API is temporarily unavailable due to an active database migration."
+            }
+          }.to_json)
+          .times(1)
+          .then
+          .to_return(:status => 200, :body => @hello_world_create_response.to_json)
+      end
+
+      it "waits for availability and retries the request" do
+        expect(Terraform::Runner).to receive(:sleep).with(check_interval).once
+
+        Terraform::Runner.run(
+          Terraform::Runner::ActionType::CREATE,
+          File.join(__dir__, "runner/data/hello-world"),
+          {}
+        )
+
+        expect(create_stub).to have_been_requested.times(2)
+      end
+    end
+  end
+
+  describe ".run_terraform_runner_stack_api with connection error handling" do
+    let(:wait_time) { 10 }
+    let(:check_interval) { 1 }
+
+    before do
+      stub_const("ENV", ENV.to_h.merge(
+                          "TERRAFORM_RUNNER_URL"                         => terraform_runner_url,
+                          "TERRAFORM_RUNNER_AVAILABILITY_WAIT_TIME"      => wait_time.to_s,
+                          "TERRAFORM_RUNNER_AVAILABILITY_CHECK_INTERVAL" => check_interval.to_s
+                        ))
+      # Reset the @available instance variable before each test
+      Terraform::Runner.instance_variable_set(:@available, nil)
+    end
+
+    context "when API raises ConnectionFailed then succeeds on retry" do
+      before do
+        # Runner is initially available
+        stub_request(:get, "#{terraform_runner_url}/ready")
+          .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
+          .times(1)
+          .then
+          # After connection failure, runner becomes unavailable then available again
+          .to_return(:status => 503, :body => {:status => "DOWN"}.to_json)
+          .times(1)
+          .then
+          .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
+      end
+
+      let!(:create_stub) do
+        stub_request(:post, "#{terraform_runner_url}/api/stack/create")
+          .to_raise(Faraday::ConnectionFailed.new("Connection refused"))
+          .times(1)
+          .then
+          .to_return(:status => 200, :body => @hello_world_create_response.to_json)
+      end
+
+      it "waits for availability and retries the request" do
+        expect(Terraform::Runner).to receive(:sleep).with(check_interval).once
+
+        Terraform::Runner.run(
+          Terraform::Runner::ActionType::CREATE,
+          File.join(__dir__, "runner/data/hello-world"),
+          {}
+        )
+
+        expect(create_stub).to have_been_requested.times(2)
+      end
+    end
+
+    context "when API raises TimeoutError then succeeds on retry" do
+      before do
+        # Runner is initially available
+        stub_request(:get, "#{terraform_runner_url}/ready")
+          .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
+          .times(1)
+          .then
+          # After timeout, runner becomes unavailable then available again
+          .to_return(:status => 503, :body => {:status => "DOWN"}.to_json)
+          .times(1)
+          .then
+          .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
+      end
+
+      let!(:create_stub) do
+        stub_request(:post, "#{terraform_runner_url}/api/stack/create")
+          .to_raise(Faraday::TimeoutError.new("Request timeout"))
+          .times(1)
+          .then
+          .to_return(:status => 200, :body => @hello_world_create_response.to_json)
+      end
+
+      it "waits for availability and retries the request" do
+        expect(Terraform::Runner).to receive(:sleep).with(check_interval).once
+
+        Terraform::Runner.run(
+          Terraform::Runner::ActionType::CREATE,
+          File.join(__dir__, "runner/data/hello-world"),
+          {}
+        )
+
+        expect(create_stub).to have_been_requested.times(2)
+      end
+    end
+  end
+
   context 'Create Stack for hello-world terraform template' do
     describe '.run create stack with input_vars' do
       before do

--- a/spec/lib/terraform/runner_spec.rb
+++ b/spec/lib/terraform/runner_spec.rb
@@ -879,6 +879,11 @@ RSpec.describe(Terraform::Runner) do
 
   context '.parse_template_variables hello-world' do
     describe '.parse_template_variables input/output vars' do
+      before do
+        stub_request(:get, "#{terraform_runner_url}/ready")
+          .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
+      end
+
       def verify_req(req)
         body = JSON.parse(req.body)
         expect(body).to(have_key('templateZipFile'))
@@ -924,6 +929,217 @@ RSpec.describe(Terraform::Runner) do
 
         terraform_version = response['terraform_version']
         expect(terraform_version).to eq('>= 1.1.0')
+      end
+    end
+
+    describe '.parse_template_variables with availability check' do
+      let(:wait_time) { 10 }
+      let(:check_interval) { 1 }
+      let(:hello_world_variables_response) { JSON.parse(File.read(File.join(__dir__, "runner/data/responses/hello-world-variables-success.json"))) }
+
+      before do
+        stub_const("ENV", ENV.to_h.merge(
+                            "TERRAFORM_RUNNER_URL"                         => terraform_runner_url,
+                            "TERRAFORM_RUNNER_AVAILABILITY_WAIT_TIME"      => wait_time.to_s,
+                            "TERRAFORM_RUNNER_AVAILABILITY_CHECK_INTERVAL" => check_interval.to_s
+                          ))
+        # Reset the @available instance variable before each test
+        Terraform::Runner.instance_variable_set(:@available, nil)
+      end
+
+      context "when runner is available" do
+        before do
+          stub_request(:get, "#{terraform_runner_url}/ready")
+            .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
+        end
+
+        let!(:template_variables_stub) do
+          stub_request(:post, "#{terraform_runner_url}/api/template/variables")
+            .to_return(:status => 200, :body => hello_world_variables_response.to_json)
+        end
+
+        it "proceeds with the API call without waiting" do
+          expect(Terraform::Runner).not_to receive(:sleep)
+
+          Terraform::Runner.parse_template_variables(File.join(__dir__, "runner/data/hello-world"))
+
+          expect(template_variables_stub).to have_been_requested.times(1)
+        end
+      end
+
+      context "when runner becomes available after waiting" do
+        before do
+          # Reset @available to ensure fresh state
+          Terraform::Runner.instance_variable_set(:@available, nil)
+
+          # First call returns unavailable, second call returns available
+          stub_request(:get, "#{terraform_runner_url}/ready")
+            .to_return(:status => 503, :body => {:status => "DOWN"}.to_json)
+            .times(1)
+            .then
+            .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
+        end
+
+        let!(:template_variables_stub) do
+          stub_request(:post, "#{terraform_runner_url}/api/template/variables")
+            .to_return(:status => 200, :body => hello_world_variables_response.to_json)
+        end
+
+        it "waits for availability then proceeds with the API call" do
+          expect(Terraform::Runner).to receive(:sleep).with(check_interval).once
+
+          Terraform::Runner.parse_template_variables(File.join(__dir__, "runner/data/hello-world"))
+
+          expect(template_variables_stub).to have_been_requested.times(1)
+        end
+      end
+
+      context "when runner never becomes available" do
+        before do
+          stub_request(:get, "#{terraform_runner_url}/ready")
+            .to_return(:status => 503, :body => {:status => "DOWN"}.to_json)
+        end
+
+        it "raises an error and does not make the API call" do
+          template_variables_stub = stub_request(:post, "#{terraform_runner_url}/api/template/variables")
+
+          expect do
+            Terraform::Runner.parse_template_variables(File.join(__dir__, "runner/data/hello-world"))
+          end.to raise_error(RuntimeError, /Terraform runner is not available after waiting/)
+
+          expect(template_variables_stub).not_to have_been_requested
+        end
+      end
+    end
+
+    describe '.parse_template_variables with 503 error handling' do
+      let(:wait_time) { 10 }
+      let(:check_interval) { 1 }
+      let(:hello_world_variables_response) { JSON.parse(File.read(File.join(__dir__, "runner/data/responses/hello-world-variables-success.json"))) }
+
+      before do
+        stub_const("ENV", ENV.to_h.merge(
+                            "TERRAFORM_RUNNER_URL"                         => terraform_runner_url,
+                            "TERRAFORM_RUNNER_AVAILABILITY_WAIT_TIME"      => wait_time.to_s,
+                            "TERRAFORM_RUNNER_AVAILABILITY_CHECK_INTERVAL" => check_interval.to_s
+                          ))
+        # Reset the @available instance variable before each test
+        Terraform::Runner.instance_variable_set(:@available, nil)
+      end
+
+      context "when API returns 503 error then succeeds on retry" do
+        before do
+          # Runner is initially available
+          stub_request(:get, "#{terraform_runner_url}/ready")
+            .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
+            .times(1)
+            .then
+            # After 503, runner becomes unavailable then available again
+            .to_return(:status => 503, :body => {:status => "DOWN"}.to_json)
+            .times(1)
+            .then
+            .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
+        end
+
+        let!(:template_variables_stub) do
+          stub_request(:post, "#{terraform_runner_url}/api/template/variables")
+            .to_return(:status => 503, :body => {
+              :error => {
+                :statusCode => 503,
+                :name       => "ServiceUnavailable",
+                :message    => "API is temporarily unavailable due to an active database migration."
+              }
+            }.to_json)
+            .times(1)
+            .then
+            .to_return(:status => 200, :body => hello_world_variables_response.to_json)
+        end
+
+        it "waits for availability and retries the request" do
+          expect(Terraform::Runner).to receive(:sleep).with(check_interval).once
+
+          Terraform::Runner.parse_template_variables(File.join(__dir__, "runner/data/hello-world"))
+
+          expect(template_variables_stub).to have_been_requested.times(2)
+        end
+      end
+    end
+
+    describe '.parse_template_variables with connection error handling' do
+      let(:wait_time) { 10 }
+      let(:check_interval) { 1 }
+      let(:hello_world_variables_response) { JSON.parse(File.read(File.join(__dir__, "runner/data/responses/hello-world-variables-success.json"))) }
+
+      before do
+        stub_const("ENV", ENV.to_h.merge(
+                            "TERRAFORM_RUNNER_URL"                         => terraform_runner_url,
+                            "TERRAFORM_RUNNER_AVAILABILITY_WAIT_TIME"      => wait_time.to_s,
+                            "TERRAFORM_RUNNER_AVAILABILITY_CHECK_INTERVAL" => check_interval.to_s
+                          ))
+        # Reset the @available instance variable before each test
+        Terraform::Runner.instance_variable_set(:@available, nil)
+      end
+
+      context "when API raises ConnectionFailed then succeeds on retry" do
+        before do
+          # Runner is initially available
+          stub_request(:get, "#{terraform_runner_url}/ready")
+            .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
+            .times(1)
+            .then
+            # After connection failure, runner becomes unavailable then available again
+            .to_return(:status => 503, :body => {:status => "DOWN"}.to_json)
+            .times(1)
+            .then
+            .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
+        end
+
+        let!(:template_variables_stub) do
+          stub_request(:post, "#{terraform_runner_url}/api/template/variables")
+            .to_raise(Faraday::ConnectionFailed.new("Connection refused"))
+            .times(1)
+            .then
+            .to_return(:status => 200, :body => hello_world_variables_response.to_json)
+        end
+
+        it "waits for availability and retries the request" do
+          expect(Terraform::Runner).to receive(:sleep).with(check_interval).once
+
+          Terraform::Runner.parse_template_variables(File.join(__dir__, "runner/data/hello-world"))
+
+          expect(template_variables_stub).to have_been_requested.times(2)
+        end
+      end
+
+      context "when API raises TimeoutError then succeeds on retry" do
+        before do
+          # Runner is initially available
+          stub_request(:get, "#{terraform_runner_url}/ready")
+            .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
+            .times(1)
+            .then
+            # After timeout, runner becomes unavailable then available again
+            .to_return(:status => 503, :body => {:status => "DOWN"}.to_json)
+            .times(1)
+            .then
+            .to_return(:status => 200, :body => {:status => "UP", :checks => []}.to_json)
+        end
+
+        let!(:template_variables_stub) do
+          stub_request(:post, "#{terraform_runner_url}/api/template/variables")
+            .to_raise(Faraday::TimeoutError.new("Request timeout"))
+            .times(1)
+            .then
+            .to_return(:status => 200, :body => hello_world_variables_response.to_json)
+        end
+
+        it "waits for availability and retries the request" do
+          expect(Terraform::Runner).to receive(:sleep).with(check_interval).once
+
+          Terraform::Runner.parse_template_variables(File.join(__dir__, "runner/data/hello-world"))
+
+          expect(template_variables_stub).to have_been_requested.times(2)
+        end
       end
     end
   end

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/configuration_script_source_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/configuration_script_source_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe(ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Config
     end
 
     before do
+      allow(Terraform::Runner).to receive(:available?).and_return(true)
+
       stub_const("ENV", ENV.to_h.merge("TERRAFORM_RUNNER_URL" => terraform_runner_url))
 
       stub_request(:post, "#{terraform_runner_url}/api/template/variables")
@@ -94,6 +96,10 @@ RSpec.describe(ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Config
     end
 
     describe "create_in_provider runs sync" do
+      before do
+        allow(Terraform::Runner).to receive(:available?).and_return(true)
+      end
+
       it "finds top level template" do
         record = build_record
 
@@ -278,6 +284,10 @@ RSpec.describe(ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Config
     end
 
     describe "#update_in_provider" do
+      before do
+        allow(Terraform::Runner).to receive(:available?).and_return(true)
+      end
+
       let(:update_params) { {:scm_branch => "other_branch"} }
 
       context "with valid params" do

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/job_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/job_spec.rb
@@ -103,6 +103,8 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
         }
       end
 
+      before { allow(Terraform::Runner).to receive(:available?).and_return(true) }
+
       it "execute the job" do
         expect(Terraform::Runner).to receive(:run).with(action_type, template_path, runner_options).and_return(response)
 
@@ -119,6 +121,27 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
                                     :git_checkout_tempdir   => git_checkout_tempdir,
                                     :terraform_stack_job_id => response.stack_job_id
                                   })
+      end
+
+      context "when runner is not available" do
+        before { allow(Terraform::Runner).to receive(:available?).and_return(false) }
+
+        it "requeues to poll_execute" do
+          expect(job).to receive(:queue_signal).with(:poll_execute, :deliver_on => kind_of(Time))
+          job.execute
+        end
+      end
+
+      context "when runner raises TemporarilyUnavailable during run" do
+        before do
+          allow(Terraform::Runner).to receive(:run).and_raise(Terraform::Runner::TemporarilyUnavailable, "503")
+        end
+
+        it "requeues to poll_execute" do
+          expect(job).to receive(:queue_signal).with(:poll_execute, :deliver_on => kind_of(Time))
+          job.execute
+          expect(job.options[:runner_wait_started_at]).to be_a(Time)
+        end
       end
     end
 
@@ -161,6 +184,8 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
             :stack_id                    => terraform_stack_id
           }
         end
+
+        before { allow(Terraform::Runner).to receive(:available?).and_return(true) }
 
         it "execute the job" do
           expect(Terraform::Runner).to receive(:run).with(action_type, template_path, runner_options).and_return(response)
@@ -312,18 +337,29 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
     context "when Terraform::Runner is available" do
       before { allow(Terraform::Runner).to receive(:available?).and_return(true) }
 
-      it "signals execute" do
+      it "signals execute and clears runner_wait_started_at" do
+        job.options[:runner_wait_started_at] = 5.minutes.ago.utc
         expect(job).to receive(:signal).with(:execute)
         job.poll_execute
+        expect(job.options[:runner_wait_started_at]).to be_nil
       end
     end
 
     context "when Terraform::Runner is not available" do
       before { allow(Terraform::Runner).to receive(:available?).and_return(false) }
 
-      it "requeues poll_execute" do
+      it "requeues poll_execute and records wait start time" do
         expect(job).to receive(:queue_signal).with(:poll_execute, :deliver_on => kind_of(Time))
         job.poll_execute
+        expect(job.options[:runner_wait_started_at]).to be_a(Time)
+      end
+
+      it "aborts job when max wait time exceeded" do
+        job.options[:runner_wait_started_at] = 11.minutes.ago.utc
+        job.poll_execute
+        job.reload
+        expect(job.state).to eq("finished")
+        expect(job.status).to eq("error")
       end
     end
   end
@@ -346,9 +382,11 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
       context "completed" do
         before { expect(job).to receive(:running?).and_return(false) }
 
-        it "signals post_execute" do
+        it "signals post_execute and clears runner_wait_started_at" do
+          job.options[:runner_wait_started_at] = 5.minutes.ago.utc
           expect(job).to receive(:signal).with(:post_execute)
           job.poll_runner
+          expect(job.options[:runner_wait_started_at]).to be_nil
         end
       end
     end
@@ -356,9 +394,31 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
     context "when Terraform::Runner is not available" do
       before { allow(Terraform::Runner).to receive(:available?).and_return(false) }
 
+      it "requeues poll_runner and records wait start time" do
+        expect(job).to receive(:queue_signal).with(:poll_runner, :deliver_on => kind_of(Time))
+        job.poll_runner
+        expect(job.options[:runner_wait_started_at]).to be_a(Time)
+      end
+
+      it "aborts job when max wait time exceeded" do
+        job.options[:runner_wait_started_at] = 11.minutes.ago.utc
+        job.poll_runner
+        job.reload
+        expect(job.state).to eq("finished")
+        expect(job.status).to eq("error")
+      end
+    end
+
+    context "when running? raises TemporarilyUnavailable" do
+      before do
+        allow(Terraform::Runner).to receive(:available?).and_return(true)
+        allow(job).to receive(:running?).and_raise(Terraform::Runner::TemporarilyUnavailable, "503")
+      end
+
       it "requeues poll_runner" do
-        job.signal(:poll_runner)
-        expect(job.reload.state).to eq("running")
+        expect(job).to receive(:queue_signal).with(:poll_runner, :deliver_on => kind_of(Time))
+        job.poll_runner
+        expect(job.options[:runner_wait_started_at]).to be_a(Time)
       end
     end
   end

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/job_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/job_spec.rb
@@ -184,7 +184,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
   end
 
   describe "#signal" do
-    %w[start pre_execute execute poll_runner post_execute finish abort_job cancel error].each do |signal|
+    %w[start pre_execute poll_execute execute poll_runner post_execute finish abort_job cancel error].each do |signal|
       shared_examples_for "allows #{signal} signal" do
         it signal.to_s do
           expect(job).to receive(signal.to_sym)
@@ -203,6 +203,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
 
       it_behaves_like "allows start signal"
       it_behaves_like "doesn't allow pre_execute signal"
+      it_behaves_like "doesn't allow poll_execute signal"
       it_behaves_like "doesn't allow execute signal"
       it_behaves_like "doesn't allow poll_runner signal"
       it_behaves_like "doesn't allow post_execute signal"
@@ -217,7 +218,23 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
 
       it_behaves_like "doesn't allow start signal"
       it_behaves_like "allows pre_execute signal"
+      it_behaves_like "doesn't allow poll_execute signal"
       it_behaves_like "doesn't allow execute signal"
+      it_behaves_like "doesn't allow poll_runner signal"
+      it_behaves_like "doesn't allow post_execute signal"
+      it_behaves_like "allows finish signal"
+      it_behaves_like "allows abort_job signal"
+      it_behaves_like "allows cancel signal"
+      it_behaves_like "allows error signal"
+    end
+
+    context "execute" do
+      let(:state) { "execute" }
+
+      it_behaves_like "doesn't allow start signal"
+      it_behaves_like "doesn't allow pre_execute signal"
+      it_behaves_like "allows poll_execute signal"
+      it_behaves_like "allows execute signal"
       it_behaves_like "doesn't allow poll_runner signal"
       it_behaves_like "doesn't allow post_execute signal"
       it_behaves_like "allows finish signal"
@@ -231,6 +248,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
 
       it_behaves_like "doesn't allow start signal"
       it_behaves_like "doesn't allow pre_execute signal"
+      it_behaves_like "doesn't allow poll_execute signal"
       it_behaves_like "doesn't allow execute signal"
       it_behaves_like "allows poll_runner signal"
       it_behaves_like "allows post_execute signal"
@@ -245,6 +263,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
 
       it_behaves_like "doesn't allow start signal"
       it_behaves_like "doesn't allow pre_execute signal"
+      it_behaves_like "doesn't allow poll_execute signal"
       it_behaves_like "doesn't allow execute signal"
       it_behaves_like "doesn't allow poll_runner signal"
       it_behaves_like "doesn't allow post_execute signal"
@@ -259,6 +278,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
 
       it_behaves_like "doesn't allow start signal"
       it_behaves_like "doesn't allow pre_execute signal"
+      it_behaves_like "doesn't allow poll_execute signal"
       it_behaves_like "doesn't allow execute signal"
       it_behaves_like "doesn't allow poll_runner signal"
       it_behaves_like "doesn't allow post_execute signal"
@@ -270,30 +290,75 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
   end
 
   describe "#start" do
-    it "moves to state pre_execute" do
+    it "queues pre_execute" do
       job.signal(:start)
       expect(job.reload.state).to eq("pre_execute")
+    end
+  end
+
+  describe "#pre_execute" do
+    let(:state) { "pre_execute" }
+
+    it "queues poll_execute after checking out git repository" do
+      expect(job).to receive(:checkout_git_repository)
+      job.signal(:pre_execute)
+      expect(job.reload.state).to eq("execute")
+    end
+  end
+
+  describe "#poll_execute" do
+    let(:state) { "execute" }
+
+    context "when Terraform::Runner is available" do
+      before { allow(Terraform::Runner).to receive(:available?).and_return(true) }
+
+      it "signals execute" do
+        expect(job).to receive(:signal).with(:execute)
+        job.poll_execute
+      end
+    end
+
+    context "when Terraform::Runner is not available" do
+      before { allow(Terraform::Runner).to receive(:available?).and_return(false) }
+
+      it "requeues poll_execute" do
+        expect(job).to receive(:queue_signal).with(:poll_execute, :deliver_on => kind_of(Time))
+        job.poll_execute
+      end
     end
   end
 
   describe "#poll_runner" do
     let(:state) { "running" }
 
-    context "still running" do
-      before { expect(job).to receive(:running?).and_return(true) }
+    context "when Terraform::Runner is available" do
+      before { allow(Terraform::Runner).to receive(:available?).and_return(true) }
+
+      context "still running" do
+        before { expect(job).to receive(:running?).and_return(true) }
+
+        it "requeues poll_runner" do
+          job.signal(:poll_runner)
+          expect(job.reload.state).to eq("running")
+        end
+      end
+
+      context "completed" do
+        before { expect(job).to receive(:running?).and_return(false) }
+
+        it "signals post_execute" do
+          expect(job).to receive(:signal).with(:post_execute)
+          job.poll_runner
+        end
+      end
+    end
+
+    context "when Terraform::Runner is not available" do
+      before { allow(Terraform::Runner).to receive(:available?).and_return(false) }
 
       it "requeues poll_runner" do
         job.signal(:poll_runner)
         expect(job.reload.state).to eq("running")
-      end
-    end
-
-    context "completed" do
-      before { expect(job).to receive(:running?).and_return(false) }
-
-      it "moves to state finished" do
-        job.signal(:poll_runner)
-        expect(job.reload.state).to eq("finished")
       end
     end
   end

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/provision_spec.rb
@@ -56,6 +56,7 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
 
     it "queues check_provisioned" do
       subject.instance_variable_set(:@stack, new_stack)
+      allow(new_stack).to receive(:raw_status).and_return(new_stack.class.status_class.new(new_stack))
 
       subject.run_provision
 
@@ -73,12 +74,43 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
         expect(subject.reload).to have_attributes(:state => "finished", :status => "Error")
       end
     end
+
+    context "when Terraform::Runner is not available" do
+      before { allow(Terraform::Runner).to receive(:available?).and_return(false) }
+
+      it "requeues provision phase and records wait start time" do
+        subject.run_provision
+
+        expect(subject.reload.phase_context[:runner_wait_started_at]).to be_a(Time)
+      end
+
+      it "aborts when max wait time exceeded" do
+        subject.phase_context[:runner_wait_started_at] = 11.minutes.ago.utc
+        subject.run_provision
+
+        expect(subject.reload).to have_attributes(:state => "finished", :status => "Error")
+      end
+    end
+
+    context "when create_stack raises TemporarilyUnavailable" do
+      before do
+        allow(described_class.module_parent::Stack).to receive(:create_stack)
+          .and_raise(Terraform::Runner::TemporarilyUnavailable, "503")
+      end
+
+      it "requeues and records wait start time" do
+        subject.run_provision
+
+        expect(subject.reload.phase_context[:runner_wait_started_at]).to be_a(Time)
+      end
+    end
   end
 
   describe "check_provisioned" do
     let(:phase) { "check_provisioned" }
 
     before do
+      allow(new_stack).to receive(:raw_status).and_return(new_stack.class.status_class.new(new_stack))
       subject.instance_variable_set(:@stack, new_stack)
       subject.phase_context[:stack_id] = new_stack.id
     end
@@ -127,27 +159,6 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
           :status => "Error"
         )
       end
-    end
-  end
-
-  describe "#post_provision" do
-    let(:phase)           { "post_provision" }
-    let(:miq_task_state)  { MiqTask::STATE_FINISHED }
-    let(:miq_task_status) { MiqTask::STATUS_ERROR }
-
-    before do
-      subject.instance_variable_set(:@stack, new_stack)
-      subject.phase_context[:stack_id] = new_stack.id
-    end
-
-    it "sets the provision message" do
-      subject.signal(:post_provision)
-
-      expect(subject.reload).to have_attributes(
-        :state   => "finished",
-        :status  => "Error",
-        :message => "[MiqException::MiqProvisionError]: Failed to provision stack"
-      )
     end
   end
 

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/provision_spec.rb
@@ -39,6 +39,7 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
     before do
       allow(Service).to receive(:find_by).and_return(service)
       allow(described_class.module_parent::Stack).to receive(:create_stack).with(terraform_template, stack_options).and_return(new_stack)
+      allow(Terraform::Runner).to receive(:available?).and_return(true)
     end
 
     it "calls create_stack" do

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/stack_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/stack_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack 
       let(:terraform_runner_stdout_html) { TerminalToHtml.render(terraform_runner_stdout) }
 
       before do
+        allow(Terraform::Runner).to receive(:available?).and_return(true)
         stub_const("ENV", ENV.to_h.merge("TERRAFORM_RUNNER_URL" => terraform_runner_url))
 
         stub_request(:post, "#{terraform_runner_url}/api/stack/retrieve")
@@ -125,6 +126,8 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack 
         EmbeddedTerraformEvmSpecHelper.assign_embedded_terraform_role
 
         allow_any_instance_of(ManageIQ::Providers::EmbeddedTerraform::AutomationManager::ConfigurationScriptSource).to receive(:checkout_git_repository)
+
+        allow(Terraform::Runner).to receive(:available?).and_return(true)
       end
 
       describe "#raw_stdout_via_worker with no errors" do

--- a/terraform-runner-availability-handling.md
+++ b/terraform-runner-availability-handling.md
@@ -1,0 +1,92 @@
+# Embedded Terraform Runner Availability Handling
+
+This document explains how the Embedded Terraform provider handles temporary unavailability of the Terraform Runner service (e.g., during OOM restarts, data migrations after upgrades, or network issues).
+
+## Design Principles
+
+1. **Never block a worker** — No `sleep` loops or waiting in the HTTP layer. Workers remain free to process other requests including UI actions.
+2. **Requeue at the job level** — When the Terraform Runner is unavailable, jobs requeue themselves via MiqQueue with a delay, freeing the worker immediately.
+3. **Fail fast at the HTTP layer** — The `Terraform::Runner.post` method makes one attempt. On 503 or connection failure, it raises `Terraform::Runner::TemporarilyUnavailable` immediately.
+4. **Availability-cache TTL** — `Terraform::Runner.available?` caches `false` results for a configurable duration (default 30 seconds) to avoid hammering the `/ready` endpoint when the service is down.
+5. **Give up after TTL** — Jobs track how long they've been waiting and abort after a configurable maximum (default 10 minutes).
+
+## How It Works
+
+### `Terraform::Runner.available?`
+
+- Calls the `/ready` health endpoint on the Terraform Runner service.
+- Returns `true` if the service responds with `{"status": "UP"}`.
+- Caches `true` indefinitely (until reset by a failed API call).
+- Caches `false` for a availability-cache TTL (default 30 seconds, configurable via `TERRAFORM_RUNNER_AVAILABILITY_CACHE_TTL`).
+- After the availability-cache TTL expires, the next call re-checks `/ready`.
+
+### `Terraform::Runner::TemporarilyUnavailable`
+
+A custom exception raised by `Terraform::Runner.post` when:
+- The API returns HTTP 503 (Service Unavailable)
+- A `Faraday::ConnectionFailed` or `Faraday::TimeoutError` occurs
+
+When raised, the availability cache is immediately reset (both `@available` and `@available_checked_at` cleared) so the next `available?` call re-checks.
+
+### Job State Machine (Provision/Reconfigure/Retire)
+
+The Job lifecycle includes availability checks at key points:
+
+1. **`poll_execute`** — Before executing, checks `available?`. If unavailable, requeues itself with a delay.
+2. **`execute`** — Double-checks `available?` before calling `Terraform::Runner.run(...)`. Also rescues `TemporarilyUnavailable` (race condition window) and requeues.
+3. **`poll_runner`** — Checks `available?` before polling stack status. Also rescues `TemporarilyUnavailable` from `retrieve_stack` and requeues.
+
+### Provision State Machine (ServiceEmbeddedTerraform)
+
+1. **`run_provision`** — Checks `available?` before signaling provision. If unavailable, requeues phase.
+2. **`provision`** — Double-checks `available?` and rescues `TemporarilyUnavailable` from `Stack.create_stack`.
+
+### Stack Deletion (Retirement)
+
+1. **`delete_stack`** — Checks `available?` before calling `raw_delete_stack`. If unavailable, requeues via `MiqQueue`.
+2. **`raw_delete_stack`** — Rescues `TemporarilyUnavailable` and requeues.
+
+### TTL-Based Give-Up
+
+All requeue paths track a `runner_wait_started_at` timestamp:
+- **Job**: stored in `options[:runner_wait_started_at]`
+- **Provision**: stored in `phase_context[:runner_wait_started_at]`
+- **Stack delete**: stored in `options[:runner_wait_started_at]`
+
+On each requeue cycle, elapsed time is checked. If it exceeds `TERRAFORM_RUNNER_AVAILABILITY_MAX_WAIT_TIME` (default 600 seconds / 10 minutes), the operation is aborted/failed rather than requeuing forever.
+
+When the runner becomes available again, the timestamp is cleared.
+
+## Scenarios
+
+### Scenario 1: ManageIQ and Terraform Runner upgraded together
+
+Both services restart. ManageIQ's cached availability state is cleared. Jobs check `available?`, find the runner not ready, and requeue. Once the runner finishes migration and reports `UP`, jobs proceed normally.
+
+### Scenario 2: Only Terraform Runner is upgraded (ManageIQ not restarted)
+
+ManageIQ may have `available?` cached as `true`. A job attempts an API call. If the runner returns 503 or is unreachable, `TemporarilyUnavailable` is raised. The job catches it, resets the cache, and requeues. Subsequent jobs see `available? == false` (from availability cache) and requeue without making API calls.
+
+### Scenario 3: Terraform Runner restarts unexpectedly (OOM)
+
+Same as Scenario 2. The first job to encounter the failure resets the cache. Other jobs benefit from the availability-cache TTL and requeue immediately.
+
+### Scenario 4: UI requests (parse_template_variables, retrieve_stack)
+
+These calls go through `Terraform::Runner.post` which fails fast. If the runner is unavailable, `TemporarilyUnavailable` is raised to the caller immediately — no blocking. The UI should handle this gracefully (display an error message).
+
+## Configuration (Environment Variables)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TERRAFORM_RUNNER_URL` | `https://opentofu-runner:6000` | Terraform Runner service URL |
+| `TERRAFORM_RUNNER_AVAILABILITY_CACHE_TTL` | `30` | Seconds to cache `available? == false` before re-checking |
+| `TERRAFORM_RUNNER_AVAILABILITY_MAX_WAIT_TIME` | `600` | Maximum seconds a job will wait (via requeue) for the runner before giving up |
+
+## Summary
+
+- Workers are never blocked by Terraform Runner unavailability.
+- UI requests fail fast with an error.
+- Background jobs requeue themselves with a 30-second delay, up to 10 minutes total.
+- If the runner doesn't recover within the TTL, jobs are aborted with a clear error message.
+- The availability-cache TTL prevents excessive health-check traffic during outages.


### PR DESCRIPTION
## Handle Terraform Runner Unavailability Without Blocking Workers

### Problem

The Terraform Runner service can become temporarily unavailable during:
- **Data migration after upgrade** — cipher migration at boot can take 7+ minutes with 10,000 records, returning HTTP 503 while running
- **OOM restarts** — the pod/container is killed and restarted, causing connection failures
- **Network transients** — brief connectivity issues between ManageIQ and the runner service

**Before this PR**, when the Terraform Runner was unreachable, the ManageIQ worker that made the API call would be fail — there was no availability check, no retry strategy, and the worker thread was stuck waiting on the HTTP timeout. 

### Solution

Introduce a **non-blocking, queue-based resilience strategy** that keeps workers free at all times:

1. **Fail-fast HTTP layer** — `Terraform::Runner` now makes exactly one HTTP attempt per API call. On 503 or connection/timeout failure, it raises `Terraform::Runner::TemporarilyUnavailable` immediately — no sleep, no retry loop.

2. **Availability check with caching** — A new `Terraform::Runner.available?` method checks the `/ready` health endpoint. Results are cached:
   - `true` is cached indefinitely (until a failed API call resets it)
   - `false` is cached for a configurable TTL (default 30s) to avoid hammering `/ready`

3. **Queue-based requeue at the job level** — Before every Runner API call, jobs/tasks check `available?`. If unavailable, they requeue themselves via MiqQueue with a 30-second delay and return immediately, freeing the worker.

4. **TTL-based give-up** — Each requeue path tracks a `runner_wait_started_at` timestamp. If the total elapsed wait exceeds a configurable max (default 10 minutes), the job aborts with a clear error rather than retrying forever.

5. **Race-condition protection** — Even if `available?` returns `true`, the actual API call can still fail if the service goes down between the check and the POST. All API-calling methods rescue `TemporarilyUnavailable` and requeue.

### Changes

**`lib/terraform/runner.rb`**
- Add `Terraform::Runner::TemporarilyUnavailable` exception class
- Rewrite `available?` with mutex-protected availability check + configurable cache TTL for `false` results
- Add `reset_available!` public method for cache invalidation
- Replace direct `terraform_runner_client.post(...)` calls with a new private `post` method that raises `TemporarilyUnavailable` on 503 / `Faraday::ConnectionFailed` / `Faraday::TimeoutError`
- Add `availability_max_wait_time` (public) — configurable max wait for requeue callers
- Add `availability_cache_ttl` (private) — configurable cache duration for `false`
- Thread-safe with `Mutex` synchronization

**`app/models/.../automation_manager/job.rb`**
- Add `poll_execute` state — inserted between `pre_execute` and `execute`; checks runner availability before proceeding
- `execute` — pre-checks `available?`, rescues `TemporarilyUnavailable`
- `poll_runner` — pre-checks `available?`, rescues `TemporarilyUnavailable` (from `retrieve_stack`)
- Add `requeue_or_abort_on_runner_unavailable` helper — timestamps, checks TTL, requeues or aborts
- Add `:poll_execute` to state machine transitions
- Reduce default `poll_interval` from 1 minute to 30 seconds

**`app/models/.../automation_manager/provision/state_machine.rb`**
- `run_provision` — checks `available?` before signaling `:provision`; requeues phase if unavailable
- `provision` — pre-checks `available?`, rescues `TemporarilyUnavailable` from `Stack.create_stack`
- Add `requeue_or_abort_on_runner_unavailable` — uses `phase_context[:runner_wait_started_at]`, TTL-based abort
- Fix error handling: replace `raise MiqException::MiqProvisionError` with `update_and_notify_parent` + `signal :finish` (proper pattern for Provision tasks)

**`app/models/.../automation_manager/stack.rb`**
- Add `delete_stack` method — wraps `raw_delete_stack` with availability check
- `raw_delete_stack` — rescues `TemporarilyUnavailable` and requeues
- Add `queue_delete_stack` — schedules retry via `MiqQueue` with configurable delay
- Add `requeue_or_fail_on_runner_unavailable` — timestamps, checks TTL, requeues or raises error

### Configuration

| Environment Variable | Default | Description |
|---|---|---|
| `TERRAFORM_RUNNER_AVAILABILITY_CACHE_TTL` | `30` (seconds) | How long to cache `available? == false` before re-checking `/ready` |
| `TERRAFORM_RUNNER_AVAILABILITY_MAX_WAIT_TIME` | `600` (seconds) | Maximum time a job will wait (via requeue cycles) before aborting |

### Flow

```
Job enters poll_execute / execute / poll_runner
  ├─ Terraform::Runner.available?
  │   ├─ true (cached or fresh /ready check)
  │   │   └─ Proceed with API call
  │   │       ├─ Success → continue state machine
  │   │       └─ 503 / ConnectionFailed / TimeoutError
  │   │           └─ Raise TemporarilyUnavailable
  │   │               └─ Reset availability cache
  │   │               └─ requeue_or_abort (check TTL)
  │   └─ false (cached within TTL — no HTTP call made)
  │       └─ requeue_or_abort (check TTL)
  │           ├─ Within max wait → requeue with 30s delay
  │           └─ Exceeded max wait → abort job with error
```

### Key Design Decisions

- **No sleep/blocking anywhere** — all waiting happens via MiqQueue delivery scheduling
- **Workers stay free** — a provisioning delay does not block UI requests
- **Availability-cache prevents thundering herd** — when runner is down, N concurrent jobs all return `false` from cache without N HTTP calls to `/ready`
- **Single retry point** — requeue logic is centralized in `requeue_or_abort_on_runner_unavailable` per component
- **Configurable timeouts** — operators can tune both cache TTL and max wait time for their environment

### Testing

All specs pass: **378 examples, 0 failures**

Specs added for:
- `available?` caching behavior (positive cache, negative cache with TTL, expiry)
- `TemporarilyUnavailable` raised on 503, ConnectionFailed, TimeoutError (for both `run` and `parse_template_variables`)
- `reset_available!` cache invalidation
- Job `poll_execute` / `execute` / `poll_runner` — requeue on unavailability, abort on TTL exceeded, rescue TemporarilyUnavailable
- Provision `run_provision` — requeue and TTL abort
- Stack stubs for `available?`