### PR TITLE
Fix retirement process for Embedded Terraform stacks with proper key transformation

### DIFF
--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb
@@ -165,11 +165,15 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
   end
 
   def service_resource
-    @service_resource ||= service_resources.find_by(:resource => self)
+    return @service_resource if defined?(@service_resource)
+
+    @service_resource = service_resources.find_by(:resource => self)
   end
 
   def delete_job
-    @delete_job ||= ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job.find_by(:target_id => id, :target_class => self.class.name)
+    return @delete_job if defined?(@delete_job)
+
+    @delete_job = ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job.find_by(:target_id => id, :target_class => self.class.name)
   end
 
   def delete_miq_task

--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb
@@ -67,7 +67,7 @@ class ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack < ManageI
     terraform_template = configuration_script_payload
     raise MiqException::Error, "Cannot delete stack, configuration script payload not found for stack:#{id}" if terraform_template.nil?
 
-    job_options = service_resource.options.slice("input_vars", "credentials")
+    job_options = service_resource.options.slice("input_vars", "credentials").transform_keys(&:to_sym)
     job_options[:action] = ResourceAction::RETIREMENT
     job_options[:terraform_stack_id] = terraform_runner_stack_id
 

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/job_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/job_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
       :input_vars    => input_vars
     }
   end
-  let(:credentials) { [] }
+  let!(:auth) { FactoryBot.create(:authentication) }
+  let(:credentials) { [auth.id] }
   let(:terraform_stack_id) { '999-999-999-999' }
 
   describe ".create_job" do
@@ -97,7 +98,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
         {
           :input_vars                  => input_vars,
           :input_vars_type_constraints => {"name" => terraform_template_payload.dig(:input_vars, 0)},
-          :credentials                 => [],
+          :credentials                 => Authentication.where(:id => credentials),
           :env_vars                    => {}
         }
       end
@@ -111,7 +112,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
                                     :template_id            => template.id,
                                     :env_vars               => {},
                                     :job_vars               => job_vars,
-                                    :credentials            => [],
+                                    :credentials            => credentials,
                                     :poll_interval          => 1.minute,
                                     :action                 => ResourceAction::PROVISION,
                                     :terraform_stack_id     => response.stack_id,
@@ -155,7 +156,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
           {
             :input_vars                  => input_vars,
             :input_vars_type_constraints => {"name" => terraform_template_payload.dig(:input_vars, 0)},
-            :credentials                 => [],
+            :credentials                 => Authentication.where(:id => credentials),
             :env_vars                    => {},
             :stack_id                    => terraform_stack_id
           }
@@ -170,7 +171,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Job do
                                       :template_id            => template.id,
                                       :env_vars               => {},
                                       :job_vars               => job_vars,
-                                      :credentials            => [],
+                                      :credentials            => credentials,
                                       :poll_interval          => 1.minute,
                                       :action                 => action,
                                       :terraform_stack_id     => response.stack_id,

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/provision_spec.rb
@@ -136,6 +136,7 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
     let(:job) { FactoryBot.create(:embedded_terraform_job, :options => job_options) }
     let(:job_options) { {:terraform_stack_id => "c247b890-4af1-11f1-bd0c-0f4596b0f2c6", :terraform_stack_job_id => "1"} }
     let!(:service_resource) { FactoryBot.create(:service_resource, :service => service, :resource => new_stack) }
+    let!(:auth) { FactoryBot.create(:authentication) }
 
     before do
       subject.phase_context[:stack_id] = new_stack.id
@@ -158,13 +159,16 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
           "dialog_var1" => "value1",
           "dialog_var2" => "value2"
         }
-        subject.options[:credential_id] = 123
+        subject.options[:credential_id] = auth.id
+
+        # Mock the authentication for credential translation
+        allow(Authentication).to receive(:find).with(auth.id).and_return(auth)
 
         # Update service_resource with provision options
         service_resource.update!(
           :options => {
             "input_vars"  => {"var1" => "value1", "var2" => "value2"},
-            "credentials" => [123]
+            "credentials" => [auth.id]
           }
         )
 
@@ -172,7 +176,7 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
 
         service_resource.reload
         expect(service_resource.options["input_vars"]).to eq({"var1" => "value1", "var2" => "value2"})
-        expect(service_resource.options["credentials"]).to eq([123])
+        expect(service_resource.options["credentials"]).to eq([auth.id])
         expect(service_resource.options["terraform_runner_stack_id"]).to eq(job_options[:terraform_stack_id])
       end
     end
@@ -220,6 +224,7 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
         :terraform_stack_job_id => "job-xyz-456"
       }
     end
+    let!(:auth) { FactoryBot.create(:authentication) }
     let!(:service_resource) do
       FactoryBot.create(
         :service_resource,
@@ -228,7 +233,7 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
         :name     => "Provision",
         :options  => {
           "input_vars"  => {"region" => "us-east-1", "instance_type" => "t2.micro"},
-          "credentials" => [789]
+          "credentials" => [auth.id]
         }
       )
     end
@@ -251,7 +256,7 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
 
         # Verify input_vars and credentials are preserved
         expect(service_resource.options["input_vars"]).to eq({"region" => "us-east-1", "instance_type" => "t2.micro"})
-        expect(service_resource.options["credentials"]).to eq([789])
+        expect(service_resource.options["credentials"]).to eq([auth.id])
       end
 
       it "ensures service_resource options can be used for retirement with symbol keys" do
@@ -263,7 +268,7 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
 
         expect(retirement_options).to eq({
                                            :input_vars  => {"region" => "us-east-1", "instance_type" => "t2.micro"},
-                                           :credentials => [789]
+                                           :credentials => [auth.id]
                                          })
       end
     end

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/provision_spec.rb
@@ -141,7 +141,6 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
       subject.phase_context[:stack_id] = new_stack.id
       new_stack.update(:miq_task => miq_task)
       miq_task.update(:job => job)
-      allow(new_stack).to receive(:raw_status).and_return(new_stack.class.status_class.new(new_stack))
     end
 
     context "when all data is present" do
@@ -151,6 +150,30 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
         service_resource.reload
         expect(service_resource.options["terraform_runner_stack_id"]).to eq(job_options[:terraform_stack_id])
         expect(service_resource.options["terraform_runner_stack_job_id"]).to eq(job_options[:terraform_stack_job_id])
+      end
+
+      it "stores input_vars and credentials for retirement" do
+        # Set up provision options with input_vars and credentials
+        subject.options[:dialog] = {
+          "dialog_var1" => "value1",
+          "dialog_var2" => "value2"
+        }
+        subject.options[:credential_id] = 123
+
+        # Update service_resource with provision options
+        service_resource.update!(
+          :options => {
+            "input_vars"  => {"var1" => "value1", "var2" => "value2"},
+            "credentials" => [123]
+          }
+        )
+
+        subject.send(:update_stack_resource_data!)
+
+        service_resource.reload
+        expect(service_resource.options["input_vars"]).to eq({"var1" => "value1", "var2" => "value2"})
+        expect(service_resource.options["credentials"]).to eq([123])
+        expect(service_resource.options["terraform_runner_stack_id"]).to eq(job_options[:terraform_stack_id])
       end
     end
 
@@ -184,6 +207,64 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
         allow_any_instance_of(ServiceResource).to receive(:update!).and_raise("ERROR")
         expect($embedded_terraform_log).to receive(:warn).with("Failed to update stack resource options: ERROR")
         subject.send(:update_stack_resource_data!)
+      end
+    end
+  end
+
+  describe "retirement data preparation" do
+    let(:phase) { "post_provision" }
+    let(:job) { FactoryBot.create(:embedded_terraform_job, :options => job_options) }
+    let(:job_options) do
+      {
+        :terraform_stack_id     => "stack-abc-123",
+        :terraform_stack_job_id => "job-xyz-456"
+      }
+    end
+    let!(:service_resource) do
+      FactoryBot.create(
+        :service_resource,
+        :service  => service,
+        :resource => new_stack,
+        :name     => "Provision",
+        :options  => {
+          "input_vars"  => {"region" => "us-east-1", "instance_type" => "t2.micro"},
+          "credentials" => [789]
+        }
+      )
+    end
+
+    before do
+      subject.phase_context[:stack_id] = new_stack.id
+      new_stack.update(:miq_task => miq_task)
+      miq_task.update(:job => job)
+    end
+
+    context "when provisioning completes successfully" do
+      it "stores all required data for retirement in service_resource" do
+        subject.send(:update_stack_resource_data!)
+
+        service_resource.reload
+
+        # Verify terraform runner IDs are stored
+        expect(service_resource.options["terraform_runner_stack_id"]).to eq("stack-abc-123")
+        expect(service_resource.options["terraform_runner_stack_job_id"]).to eq("job-xyz-456")
+
+        # Verify input_vars and credentials are preserved
+        expect(service_resource.options["input_vars"]).to eq({"region" => "us-east-1", "instance_type" => "t2.micro"})
+        expect(service_resource.options["credentials"]).to eq([789])
+      end
+
+      it "ensures service_resource options can be used for retirement with symbol keys" do
+        subject.send(:update_stack_resource_data!)
+        service_resource.reload
+
+        # Simulate what raw_delete_stack does: slice and transform keys to symbols
+        retirement_options = service_resource.options.slice("input_vars", "credentials").transform_keys(&:to_sym)
+
+        expect(retirement_options).to eq({
+                                           :input_vars  => {"region" => "us-east-1", "instance_type" => "t2.micro"},
+                                           :credentials => [789]
+                                         })
       end
     end
   end

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/provision_spec.rb
@@ -161,9 +161,6 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
         }
         subject.options[:credential_id] = auth.id
 
-        # Mock the authentication for credential translation
-        allow(Authentication).to receive(:find).with(auth.id).and_return(auth)
-
         # Update service_resource with provision options
         service_resource.update!(
           :options => {

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/stack_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/stack_spec.rb
@@ -248,7 +248,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack 
           double("ServiceResource", :options => {
                    "terraform_runner_stack_id" => "stack-123",
                    "input_vars"                => {"key" => "value"},
-                   "credentials"               => ["999"]
+                   "credentials"               => [999]
                  })
         end
 
@@ -259,8 +259,8 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack 
 
         it "creates a delete job with correct options" do
           expected_options = {
-            "input_vars"        => {"key" => "value"},
-            "credentials"       => ["999"],
+            :input_vars         => {"key" => "value"},
+            :credentials        => [999],
             :action             => ResourceAction::RETIREMENT,
             :terraform_stack_id => "stack-123"
           }

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/stack_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/stack_spec.rb
@@ -244,11 +244,12 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack 
       end
 
       context "when all required data is present" do
+        let!(:auth) { FactoryBot.create(:authentication) }
         let(:service_resource) do
           double("ServiceResource", :options => {
                    "terraform_runner_stack_id" => "stack-123",
                    "input_vars"                => {"key" => "value"},
-                   "credentials"               => [999]
+                   "credentials"               => [auth.id]
                  })
         end
 
@@ -260,7 +261,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Stack 
         it "creates a delete job with correct options" do
           expected_options = {
             :input_vars         => {"key" => "value"},
-            :credentials        => [999],
+            :credentials        => [auth.id],
             :action             => ResourceAction::RETIREMENT,
             :terraform_stack_id => "stack-123"
           }


### PR DESCRIPTION
# Summary

This pull request fixes the retirement process for Embedded Terraform stacks by ensuring that job options are properly transformed to use symbol keys and improves memoization patterns for better handling of nil values.

## Changes Made

### 🔧 Core Changes
- **Key Transformation**: Updated `raw_delete_stack` to transform hash keys from strings to symbols using `.transform_keys(&:to_sym)` when slicing `input_vars` and `credentials` from service_resource options
- **Improved Memoization**: Enhanced `service_resource` and `delete_job` methods to properly handle nil values by checking if instance variables are defined

### ✅ Test Coverage
- Updated existing stack specs to expect symbol keys in retirement options
- Added comprehensive retirement data preparation specs in provision_spec.rb
- Verified that provisioning properly stores data needed for retirement

## Files Changed

📄 **app/models/manageiq/providers/embedded_terraform/automation_manager/stack.rb**
- Line 70: Added `.transform_keys(&:to_sym)` to ensure consistent symbol keys
- Lines 168-170, 173-175: Improved memoization pattern using `defined?(@variable)`

📄 **spec/models/manageiq/providers/embedded_terraform/automation_manager/stack_spec.rb**
- Line 262-264: Updated expected options to use symbol keys (`:input_vars`, `:credentials`)

📄 **spec/models/manageiq/providers/embedded_terraform/automation_manager/provision_spec.rb**
- Lines 156-177: Added test for storing input_vars and credentials during provisioning
- Lines 191-245: Added comprehensive retirement data preparation specs