### PR TITLE
Use worker_settings starting_timeout for readinessProbe

### DIFF
--- a/app/models/opentofu_worker.rb
+++ b/app/models/opentofu_worker.rb
@@ -43,10 +43,12 @@ class OpentofuWorker < MiqWorker
   end
 
   def add_readiness_probe(container_definition)
+    starting_timeout = self.class.worker_settings[:starting_timeout] || 3
+
     container_definition[:readinessProbe] = {
       :httpGet             => {:path => "/ready", :port => SERVICE_PORT, :scheme => "HTTPS"},
       :initialDelaySeconds => 60,
-      :timeoutSeconds      => 3
+      :timeoutSeconds      => starting_timeout
     }
   end
 


### PR DESCRIPTION
Follow-up to https://github.com/ManageIQ/manageiq/pull/23851 for the `OpentofuWorker` which overrides the `add_readiness_probe` method.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
