### PR TITLE
Fix NoMethodError abort_job when provision fails

### DIFF
--- a/app/models/manageiq/providers/embedded_terraform/automation_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/embedded_terraform/automation_manager/provision/state_machine.rb
@@ -29,7 +29,7 @@ module ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision::Sta
     if succeeded?
       signal :mark_as_completed
     else
-      abort_job("Failed to provision stack", "error")
+      raise MiqException::MiqProvisionError, "Failed to provision stack"
     end
   end
 

--- a/spec/models/manageiq/providers/embedded_terraform/automation_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/embedded_terraform/automation_manager/provision_spec.rb
@@ -55,7 +55,6 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
 
     it "queues check_provisioned" do
       subject.instance_variable_set(:@stack, new_stack)
-      allow(new_stack).to receive(:raw_status).and_return(new_stack.class.status_class.new(new_stack))
 
       subject.run_provision
 
@@ -79,7 +78,6 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
     let(:phase) { "check_provisioned" }
 
     before do
-      allow(new_stack).to receive(:raw_status).and_return(new_stack.class.status_class.new(new_stack))
       subject.instance_variable_set(:@stack, new_stack)
       subject.phase_context[:stack_id] = new_stack.id
     end
@@ -128,6 +126,27 @@ describe ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision do
           :status => "Error"
         )
       end
+    end
+  end
+
+  describe "#post_provision" do
+    let(:phase)           { "post_provision" }
+    let(:miq_task_state)  { MiqTask::STATE_FINISHED }
+    let(:miq_task_status) { MiqTask::STATUS_ERROR }
+
+    before do
+      subject.instance_variable_set(:@stack, new_stack)
+      subject.phase_context[:stack_id] = new_stack.id
+    end
+
+    it "sets the provision message" do
+      subject.signal(:post_provision)
+
+      expect(subject.reload).to have_attributes(
+        :state   => "finished",
+        :status  => "Error",
+        :message => "[MiqException::MiqProvisionError]: Failed to provision stack"
+      )
     end
   end
 


### PR DESCRIPTION
When a stack provision fails we were calling `abort_job` which does not exist for an instance of MiqRequestTask::StateMachine.  It does for a `Job::StateMachine` which is where the confusion came from.

The job is going to fail either way, so failing because of NoMethodError just means we have a misleading reason why it failed.

Fixes:
`<AEMethod update_serviceprovision_status> Service Provision Error: Server [EVM] Service [NewTFAutomate-20260610-160001] Step [checkprovisioned] Status [Error Creating Service] Message [[NoMethodError]: undefined method 'abort_job' for an instance of ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Provision]`
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
