### PR TITLE
Fix credential_id for provision workflow

### DIFF
--- a/app/models/service_embedded_terraform_mixin.rb
+++ b/app/models/service_embedded_terraform_mixin.rb
@@ -27,7 +27,7 @@ module ServiceEmbeddedTerraformMixin
     stack_opts = {:action => action}.merge(input_vars_from_dialog(options.merge(overrides)))
 
     if instance_of?(ServiceEmbeddedTerraform)
-      stack_opts[:credential_id] = credential_id_from_workflow_provision_request(overrides)
+      stack_opts[:credential_id] = credential_id(overrides)
     end
 
     translate_credentials!(stack_opts)
@@ -173,12 +173,14 @@ module ServiceEmbeddedTerraformMixin
     options.fetch_path(:config_info, action.downcase.to_sym).slice(*CONFIG_OPTIONS_WHITELIST).with_indifferent_access if options.key?(:config_info)
   end
 
-  def credential_id_from_workflow_provision_request(request_options)
-    credential_id = request_options[:credential_id]
+  def get_value(data)
+    data.kind_of?(Array) ? data.first : data
+  end
 
-    # If for provision_workflow, coming from customize tab, it will have a array like [id, name], and we only take id
-    credential_id = credential_id.first if credential_id.kind_of?(Array) && credential_id.first.present?
-
-    credential_id
+  def credential_id(opts)
+    # When provision:workflow, credential_id data coming from customize tab, has a array like [id, name], and we only take id
+    #   - if no credential selected or required, data has [nil, nil], then return nil
+    # When provision:automate, credential_id data has a id
+    get_value(opts[:credential_id])
   end
 end

--- a/spec/models/service_embedded_terraform_spec.rb
+++ b/spec/models/service_embedded_terraform_spec.rb
@@ -1,0 +1,94 @@
+describe ServiceEmbeddedTerraform do
+  let(:zone) { EvmSpecHelper.local_miq_server.zone }
+  let(:ems) { FactoryBot.create(:embedded_automation_manager_terraform, :zone => zone) }
+  let(:service) { FactoryBot.create(:service_embedded_terraform) }
+  let!(:auth) { FactoryBot.create(:authentication) }
+
+  describe "#stack" do
+    let!(:stack) { FactoryBot.create(:terraform_stack, :ext_management_system => ems) }
+    let!(:service_resource) do
+      FactoryBot.create(
+        :service_resource,
+        :service       => service,
+        :resource      => stack,
+        :name          => ResourceAction::PROVISION,
+        :resource_type => 'OrchestrationStack'
+      )
+    end
+
+    it "returns the stack for the given action" do
+      expect(service.stack(ResourceAction::PROVISION)).to eq(stack)
+    end
+  end
+
+  describe "#stack_opts with credential_id handling" do
+    context "when credential_id is provided as array [id, name]" do
+      it "extracts the id and includes it in stack options" do
+        overrides = {:credential_id => [auth.id, "AWS Credential"]}
+        result = service.stack_opts(ResourceAction::PROVISION, overrides)
+
+        expect(result[:credentials]).to include(auth.native_ref)
+      end
+    end
+
+    context "when credential_id is provided as array [nil, nil]" do
+      it "does not include credentials in stack options" do
+        overrides = {:credential_id => [nil, nil]}
+        result = service.stack_opts(ResourceAction::PROVISION, overrides)
+
+        expect(result[:credentials]).to be_empty
+      end
+    end
+
+    context "when credential_id is provided as single value" do
+      it "includes the credential in stack options" do
+        overrides = {:credential_id => auth.id}
+        result = service.stack_opts(ResourceAction::PROVISION, overrides)
+
+        expect(result[:credentials]).to include(auth.native_ref)
+      end
+    end
+
+    context "when no credential_id is provided" do
+      it "does not include credentials in stack options" do
+        overrides = {}
+        result = service.stack_opts(ResourceAction::PROVISION, overrides)
+
+        expect(result[:credentials]).to be_empty
+      end
+    end
+
+    context "with dialog input variables" do
+      before do
+        service.options = {
+          :dialog => {
+            "dialog_var1" => "value1",
+            "dialog_var2" => "value2"
+          }
+        }
+      end
+
+      it "includes input_vars from dialog in stack options" do
+        result = service.stack_opts(ResourceAction::PROVISION)
+
+        expect(result[:input_vars]).to include("var1" => "value1", "var2" => "value2")
+      end
+
+      it "includes both input_vars and credentials when credential_id is provided" do
+        overrides = {:credential_id => auth.id}
+        result = service.stack_opts(ResourceAction::PROVISION, overrides)
+
+        expect(result[:input_vars]).to include("var1" => "value1", "var2" => "value2")
+        expect(result[:credentials]).to include(auth.native_ref)
+      end
+
+      it "includes input_vars but no credentials when credential_id is [nil, nil]" do
+        overrides = {:credential_id => [nil, nil]}
+        result = service.stack_opts(ResourceAction::PROVISION, overrides)
+
+        expect(result[:input_vars]).to include("var1" => "value1", "var2" => "value2")
+        expect(result[:credentials]).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

When credentials coming from **Customize** tab, for provision_workflow, the credential data, will have a array like [id, name], and we only return id, else return nil.

Provisioning fails, when no credentials is selected or required for the catalog item,  this fix resolves the problem.

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
