### PR TITLE
Clarify that the permissions are intentionally 644 octal

### DIFF
--- a/app/models/opentofu_worker.rb
+++ b/app/models/opentofu_worker.rb
@@ -119,7 +119,7 @@ class OpentofuWorker < MiqWorker
     if ENV["API_SSL_SECRET_NAME"].present?
       # mounting secret for opentofu-runner SSL usage
       definition[:spec][:template][:spec][:containers].first[:volumeMounts] << {:name => "cert-path", :mountPath => "/opt/app-root/src/config/cert"}
-      definition[:spec][:template][:spec][:volumes] << {:name => "cert-path", :secret => {:secretName => ENV["API_SSL_SECRET_NAME"], :items => [{:key => "tf_runner_crt", :path => "tls.crt"}, {:key => "tf_runner_key", :path => "tls.key"}], :defaultMode => 420}}
+      definition[:spec][:template][:spec][:volumes] << {:name => "cert-path", :secret => {:secretName => ENV["API_SSL_SECRET_NAME"], :items => [{:key => "tf_runner_crt", :path => "tls.crt"}, {:key => "tf_runner_key", :path => "tls.key"}], :defaultMode => 0o644}}
     end
   end
 


### PR DESCRIPTION
The bug in ManageIQ/manageiq#23930 made it appear like the octal permission was used, but it was actually decimal. In the cases of these files, 0o644 is actually what we want (meaning 420 decimal is correct), but we are changing to octal to better clarify that.

Similar change as ManageIQ/manageiq#23931

@agrare Please review.